### PR TITLE
add support for custom type converters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,9 @@
 
    <dependencies>
       <dependency>
-         <groupId>javax.persistence</groupId>
-         <artifactId>persistence-api</artifactId>
-         <version>1.0.2</version>
+         <groupId>org.eclipse.persistence</groupId>
+         <artifactId>javax.persistence</artifactId>
+         <version>2.1.0</version>
          <scope>provided</scope>
       </dependency>
       <dependency>

--- a/src/test/java/org/sansorm/TargetClass1.java
+++ b/src/test/java/org/sansorm/TargetClass1.java
@@ -1,13 +1,9 @@
 package org.sansorm;
 
 import java.util.Date;
+import java.util.Map;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
+import javax.persistence.*;
 
 @Table(name = "target_class1")
 public class TargetClass1
@@ -24,6 +20,10 @@ public class TargetClass1
    @Column(name = "string")
    private String string;
 
+   @Column(name = "string_from_number")
+   @Convert(converter = TestConverter.class)
+   private String stringFromNumber;
+
    public TargetClass1()
    {
 
@@ -31,8 +31,14 @@ public class TargetClass1
 
    public TargetClass1(Date timestamp, String string)
    {
+      this(timestamp, string, null);
+   }
+
+   public TargetClass1(Date timestamp, String string, String stringFromNumber)
+   {
       this.timestamp = timestamp;
       this.string = string;
+      this.stringFromNumber = stringFromNumber;
    }
 
    public int getId()
@@ -49,4 +55,9 @@ public class TargetClass1
    {
       return string;
    }
+
+   public String getStringFromNumber() {
+      return stringFromNumber;
+   }
+
 }

--- a/src/test/java/org/sansorm/TestConverter.java
+++ b/src/test/java/org/sansorm/TestConverter.java
@@ -1,0 +1,21 @@
+package org.sansorm;
+
+import javax.persistence.AttributeConverter;
+
+public class TestConverter implements AttributeConverter<String, Number> {
+
+    @Override
+    public Number convertToDatabaseColumn(String value) {
+        try {
+            return Integer.parseInt(value, 10);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public String convertToEntityAttribute(Number value) {
+        return value == null ? null : value.toString();
+
+    }
+}


### PR DESCRIPTION
Hy, thanks for creating SansOrm, I really like the Idea and the Simplicity. One thing I am missing (or just haven't understood how it would be done) is how you would support more types.

What do you think of this little demo implementation of type converters? The Interface is heavily inspired by what Hibernate offers.

I created it to get a little demo with Postgres JSONB Type up and running, this would be the JSONB Converter:
```
package at.paukl.springplay.domain.converter;

import com.fasterxml.jackson.databind.ObjectMapper;
import com.zaxxer.sansorm.Converter;
import org.postgresql.util.PGobject;

import java.io.IOException;
import java.util.Map;

/**
 * @author Paul Klingelhuber
 */
public class PostgresJsonConverter implements Converter<Map, PGobject> {

    private static final ObjectMapper objectMapper = new ObjectMapper();

    @Override
    public Map fromDb(PGobject dbValue) {
        try {
            return objectMapper.readValue(dbValue.getValue(), Map.class);
        } catch (IOException e) {
            throw new RuntimeException("problem reading json object", e);
        }
    }

    @Override
    public PGobject toDb(Map javaValue) {
        PGobject pGobject = new PGobject();
        pGobject.setType("jsonb");
        try {
            pGobject.setValue(objectMapper.writeValueAsString(javaValue));
        } catch (Exception e) {
            throw new RuntimeException("problem with json object", e);
        }
        return pGobject;
    }
}
```

and this is an example class using it:

```
@Table(name="users")
public class User {
    @Id
    @Column(name="id")
    public UUID id = UUID.randomUUID();

    @Column(name="username")
    public String username;

    @Column(name="email")
    public String email;

    @Column(name="active")
    public boolean active;

    @Column(name="config")
    @Convert(converter = PostgresJsonConverter.class)
    public Map config;
}
```