### PR TITLE
Avoiding a NPE when calling OrmWriter.setParamsExecuteClose() with a …

### DIFF
--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -149,7 +149,7 @@ public class Introspected
          // Fix-up column value for enums, integer as boolean, etc.
          if (fcInfo.getConverter() != null) {
             value = fcInfo.getConverter().convertToDatabaseColumn(value);
-         } else if (fcInfo.enumConstants != null) {
+         } else if (fcInfo.enumConstants != null && value != null) {
             value = (fcInfo.enumType == EnumType.ORDINAL ? ((Enum<?>) value).ordinal() : ((Enum<?>) value).name());
          }
 


### PR DESCRIPTION
Avoiding a NPE when calling OrmWriter.setParamsExecuteClose() with a target objet holding a enum type set to null