### PR TITLE
fixed default name behavior for Column and Table annotations

### DIFF
--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -78,7 +78,10 @@ public class Introspected
 
       Table tableAnnotation = clazz.getAnnotation(Table.class);
       if (tableAnnotation != null) {
-         tableName = tableAnnotation.name();
+         String tableName = tableAnnotation.name();
+         this.tableName = (tableName == null || tableName.isEmpty())
+            ? clazz.getSimpleName() // as per documentation, empty name in Table "defaults to the entity name"
+            : tableName;
       }
 
       try {
@@ -481,12 +484,11 @@ public class Introspected
 
       Column columnAnnotation = field.getAnnotation(Column.class);
       if (columnAnnotation != null) {
-         fcInfo.columnName = columnAnnotation.name().toLowerCase();
-         String columnTableName = columnAnnotation.table();
-         if (columnTableName != null && columnTableName.length() > 0) {
-            fcInfo.columnTableName = columnTableName.toLowerCase();
-         }
-
+         String columnName = columnAnnotation.name();
+         fcInfo.columnName = (columnName == null || columnName.isEmpty())
+            ? field.getName() // as per documentation, empty name in Column "defaults to the property or field name"
+            : columnName.toLowerCase();
+         fcInfo.columnTableName = columnAnnotation.table();
          fcInfo.insertable = columnAnnotation.insertable();
          fcInfo.updatable = columnAnnotation.updatable();
       }

--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -488,7 +488,12 @@ public class Introspected
          fcInfo.columnName = (columnName == null || columnName.isEmpty())
             ? field.getName() // as per documentation, empty name in Column "defaults to the property or field name"
             : columnName.toLowerCase();
-         fcInfo.columnTableName = columnAnnotation.table();
+
+         String columnTableName = columnAnnotation.table();
+         if (columnTableName != null && !columnTableName.isEmpty()) {
+            fcInfo.columnTableName = columnTableName.toLowerCase();
+         }
+
          fcInfo.insertable = columnAnnotation.insertable();
          fcInfo.updatable = columnAnnotation.updatable();
       }

--- a/src/test/java/org/sansorm/IntrospectorTest.java
+++ b/src/test/java/org/sansorm/IntrospectorTest.java
@@ -3,6 +3,8 @@ package org.sansorm;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.persistence.*;
+
 import com.zaxxer.sansorm.internal.Introspected;
 import com.zaxxer.sansorm.internal.Introspector;
 
@@ -13,5 +15,34 @@ public class IntrospectorTest
    {
       Introspected is1 = Introspector.getIntrospected(TargetClass1.class);
       Assert.assertNotNull(is1);
+   }
+
+   @Test
+   public void shouldHandleEmptyAnnotationNames()
+   {
+      @Table
+      class SomeEntity
+      {
+         @Id
+         @GeneratedValue
+         @Column
+         private int id;
+
+         @Column
+         private String someString;
+
+         @Column(name = "SOME_OTHER_STRING") // just to demonstrate mixed case
+         private String someOtherString;
+      }
+
+      Introspected inspected = Introspector.getIntrospected(SomeEntity.class);
+      Assert.assertNotNull(inspected);
+      Assert.assertEquals("According to Table::name javadoc, empty name should default to entity name",
+         "SomeEntity", inspected.getTableName());
+      Assert.assertEquals("According to Column::name javadoc, empty name should default to field name",
+         "id", inspected.getColumnNameForProperty("id"));
+      Assert.assertEquals("someString", inspected.getColumnNameForProperty("someString"));
+      Assert.assertEquals("Explicit Column names are converted to lower case",
+         "some_other_string", inspected.getColumnNameForProperty("someOtherString"));
    }
 }


### PR DESCRIPTION
@brettwooldridge, hi.
recently i've started to migrate my project from Hibernate (which finally disappointed me) to SansOrm.
all entities in my project are annotated using only standard JPA annotations, and rely on the documented behavior that maps empty Table and Column names to entity and field names accordingly. but SansOrm expects explicit names for all of them. here's the fix to support standard documented behavior for those annotations to ease migration.

PS: also, which minimal Java version should be supported by SansOrm? pom.xml says 1.8, but code looks like somewhat between 1.6 and 1.7