### PR TITLE
fixed case-sensitivity for column names

### DIFF
--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -16,6 +16,8 @@
 
 package com.zaxxer.sansorm.internal;
 
+import org.postgresql.util.PGobject;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.Field;
@@ -29,23 +31,21 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.TreeMap;
 
 import javax.persistence.*;
-
-import org.postgresql.util.PGobject;
 
 /**
  * An introspected class.
  */
-public class Introspected
+public final class Introspected
 {
    private final Class<?> clazz;
-   private final Map<String, FieldColumnInfo> columnToField = new LinkedHashMap<>();
+   private final Map<String, FieldColumnInfo> columnToField;
    private String tableName;
 
    private FieldColumnInfo selfJoinFCInfo;
@@ -63,23 +63,23 @@ public class Introspected
    private String[] updatableColumns;
 
    /**
-    * Constructor.  Introspect the specified class and cache various annotation
-    * data about it.
+    * Constructor. Introspect the specified class and cache various annotation data about it.
     *
     * @param clazz the class to introspect
     */
    Introspected(Class<?> clazz) {
       this.clazz = clazz;
+      this.columnToField = new TreeMap<>(String.CASE_INSENSITIVE_ORDER); // support both in- and case-sensitive DBs
 
       Table tableAnnotation = clazz.getAnnotation(Table.class);
       if (tableAnnotation != null) {
          String tableName = tableAnnotation.name();
-         this.tableName = (tableName == null || tableName.isEmpty())
+         this.tableName = tableName.isEmpty()
             ? clazz.getSimpleName() // as per documentation, empty name in Table "defaults to the entity name"
             : tableName;
       }
 
-      Collection<Field> declaredFields = new LinkedList(Arrays.asList(clazz.getDeclaredFields()));
+      Collection<Field> declaredFields = new LinkedList<>(Arrays.asList(clazz.getDeclaredFields()));
       for (Class<?> c = clazz.getSuperclass(); c != null; c = c.getSuperclass()) {
          // support fields from MappedSuperclass(es)
          if (c.getAnnotation(MappedSuperclass.class) != null) {
@@ -471,12 +471,12 @@ public class Introspected
       Column columnAnnotation = field.getAnnotation(Column.class);
       if (columnAnnotation != null) {
          String columnName = columnAnnotation.name();
-         fcInfo.columnName = (columnName == null || columnName.isEmpty())
+         fcInfo.columnName = columnName.isEmpty()
             ? field.getName() // as per documentation, empty name in Column "defaults to the property or field name"
             : columnName.toLowerCase();
 
          String columnTableName = columnAnnotation.table();
-         if (columnTableName != null && !columnTableName.isEmpty()) {
+         if (!columnTableName.isEmpty()) {
             fcInfo.columnTableName = columnTableName.toLowerCase();
          }
 
@@ -511,7 +511,7 @@ public class Introspected
    /**
     * Column information about a field
     */
-   private static class FieldColumnInfo
+   private static final class FieldColumnInfo
    {
       private boolean updatable;
       private boolean insertable;

--- a/src/test/java/com/zaxxer/sansorm/internal/IntrospectedTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/IntrospectedTest.java
@@ -2,12 +2,13 @@ package com.zaxxer.sansorm.internal;
 
 import org.junit.Test;
 import org.sansorm.TargetClass1;
+
+import javax.persistence.*;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
-import javax.persistence.*;
 
 public class IntrospectedTest
 {
@@ -18,7 +19,7 @@ public class IntrospectedTest
       assertNotNull(inspected);
       assertTrue(inspected.hasGeneratedId());
       assertArrayEquals(new String[]{"id"}, inspected.getIdColumnNames());
-      assertArrayEquals(new String[]{"timestamp", "string_from_number", "id", "string"}, inspected.getColumnNames());
+      assertArrayEquals(new String[]{"id", "string", "string_from_number", "timestamp"}, inspected.getColumnNames());
    }
 
    @Test
@@ -79,6 +80,6 @@ public class IntrospectedTest
       assertEquals("string", inspected.getColumnNameForProperty("string"));
       assertTrue(inspected.hasGeneratedId());
       assertArrayEquals(new String[]{"id"}, inspected.getIdColumnNames());
-      assertArrayEquals(new String[]{"string", "id"}, inspected.getColumnNames());
+      assertArrayEquals(new String[]{"id", "string"}, inspected.getColumnNames());
    }
 }

--- a/src/test/java/org/sansorm/QueryTest.java
+++ b/src/test/java/org/sansorm/QueryTest.java
@@ -3,17 +3,13 @@ package org.sansorm;
 import bitronix.tm.BitronixTransactionManager;
 import bitronix.tm.TransactionManagerServices;
 import bitronix.tm.resource.common.XAResourceProducer;
-import com.zaxxer.sansorm.OrmElf;
-import com.zaxxer.sansorm.SqlClosure;
-import com.zaxxer.sansorm.SqlClosureElf;
-import com.zaxxer.sansorm.TransactionElf;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import javax.sql.DataSource;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.PreparedStatement;
 import java.sql.Timestamp;
@@ -21,14 +17,19 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Properties;
 
+import javax.sql.DataSource;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import com.zaxxer.sansorm.OrmElf;
+import com.zaxxer.sansorm.SqlClosure;
+import com.zaxxer.sansorm.SqlClosureElf;
+import com.zaxxer.sansorm.TransactionElf;
+
 public class QueryTest
 {
-   @BeforeClass
-   public static void setup() throws Throwable
-   {
+   static DataSource prepareTestDatasource() throws IOException {
       System.setProperty("org.slf4j.simpleLogger.log.bitronix.tm", "WARN");
 
       // We don't actually need the transaction manager to journal, this is just for testing
@@ -56,15 +57,20 @@ public class QueryTest
       TransactionElf.setUserTransaction(tm);
 
       Map<String, XAResourceProducer> resources = TransactionManagerServices.getResourceLoader().getResources();
-      Object ds = resources.values().iterator().next();
-      SqlClosure.setDefaultDataSource((DataSource) ds);
+      return (DataSource)resources.values().iterator().next();
+   }
 
+   @BeforeClass
+   public static void setup() throws Throwable
+   {
+      DataSource ds = prepareTestDatasource();
+      SqlClosure.setDefaultDataSource(ds);
       SqlClosureElf.executeUpdate("CREATE TABLE target_class1 ("
-                                  + "id INTEGER NOT NULL IDENTITY PRIMARY KEY, "
-                                  + "timestamp TIMESTAMP, "
-                                  + "string VARCHAR(128), "
-                                  + "string_from_number NUMERIC "
-                                  + ")");
+         + "id INTEGER NOT NULL IDENTITY PRIMARY KEY, "
+         + "timestamp TIMESTAMP, "
+         + "string VARCHAR(128), "
+         + "string_from_number NUMERIC "
+         + ")");
    }
 
    @AfterClass

--- a/src/test/java/org/sansorm/QueryTest2.java
+++ b/src/test/java/org/sansorm/QueryTest2.java
@@ -1,0 +1,103 @@
+package org.sansorm;
+
+import bitronix.tm.TransactionManagerServices;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import static org.junit.Assert.assertEquals;
+import static org.sansorm.QueryTest.prepareTestDatasource;
+
+import com.zaxxer.sansorm.SqlClosure;
+import com.zaxxer.sansorm.SqlClosureElf;
+
+
+public class QueryTest2
+{
+   @BeforeClass
+   public static void setup() throws Throwable
+   {
+      DataSource ds = prepareTestDatasource();
+      SqlClosure.setDefaultDataSource(ds);
+      SqlClosureElf.executeUpdate(
+         "CREATE TABLE TargetClass2 ("
+            + " id INTEGER NOT NULL IDENTITY PRIMARY KEY,"
+            + " string VARCHAR(128),"
+            + " someDate TIMESTAMP," // H2 is case-insensitive to column case, ResultSet::getMetaData will return it as SOMEDATE
+            + " )");
+   }
+
+   @AfterClass
+   public static void tearDown()
+   {
+      TransactionManagerServices.getTransactionManager().shutdown();
+   }
+
+   @Test
+   public void testObjectFromClause()
+   {
+      // given
+      int timestamp = 42;
+      String string = "Hi";
+      TargetClass2 original = new TargetClass2(new Date(timestamp), string);
+      SqlClosureElf.insertObject(original);
+
+      // when
+      TargetClass2 target = SqlClosureElf.objectFromClause(TargetClass2.class, "string = ?", string);
+      TargetClass2 targetAgain = SqlClosureElf.getObjectById(TargetClass2.class, target.getId());
+
+      // then
+      assertEquals(target.getId(), targetAgain.getId());
+      assertEquals(string, target.getString());
+      assertEquals(timestamp, target.getSomeDate().getTime());
+      assertEquals(string, targetAgain.getString());
+      assertEquals(timestamp, targetAgain.getSomeDate().getTime());
+   }
+
+   @Test
+   public void testListFromClause()
+   {
+      // given
+      int timestamp = 43;
+      String string = "Ho";
+      TargetClass2 original = new TargetClass2(new Date(timestamp), string);
+      SqlClosureElf.insertObject(original);
+
+      // when
+      List<TargetClass2> target = SqlClosureElf.listFromClause(TargetClass2.class, "string = ?", string);
+
+      // then
+      assertEquals(string, target.get(0).getString());
+      assertEquals(timestamp, target.get(0).getSomeDate().getTime());
+   }
+
+   @Test
+   public void testNumberFromSql()
+   {
+      Number initialCount = SqlClosureElf.numberFromSql("SELECT count(id) FROM TargetClass2");
+      SqlClosureElf.insertObject(new TargetClass2(null, ""));
+
+      Number newCount = SqlClosureElf.numberFromSql("SELECT count(id) FROM TargetClass2");
+      assertEquals(initialCount.intValue() + 1, newCount.intValue());
+
+      int countCount = SqlClosureElf.countObjectsFromClause(TargetClass2.class, null);
+      assertEquals(newCount.intValue(), countCount);
+   }
+
+   @Test
+   public void testDate()
+   {
+      Date date = new Date();
+
+      TargetClass2 target = SqlClosureElf.insertObject(new TargetClass2(date, "Date"));
+      target = SqlClosureElf.getObjectById(TargetClass2.class, target.getId());
+
+      assertEquals("Date", target.getString());
+      assertEquals(date, target.getSomeDate());
+   }
+}

--- a/src/test/java/org/sansorm/QueryTest2.java
+++ b/src/test/java/org/sansorm/QueryTest2.java
@@ -48,7 +48,7 @@ public class QueryTest2
       SqlClosureElf.insertObject(original);
 
       // when
-      TargetClass2 target = SqlClosureElf.objectFromClause(TargetClass2.class, "string = ?", string);
+      TargetClass2 target = SqlClosureElf.objectFromClause(TargetClass2.class, "someDate = ?", timestamp);
       TargetClass2 targetAgain = SqlClosureElf.getObjectById(TargetClass2.class, target.getId());
 
       // then

--- a/src/test/java/org/sansorm/TargetClass2.java
+++ b/src/test/java/org/sansorm/TargetClass2.java
@@ -1,0 +1,29 @@
+package org.sansorm;
+
+import java.util.Date;
+
+import javax.persistence.*;
+
+@Entity // Entity annotation
+@Table // no explicit table name
+public class TargetClass2 extends BaseClass
+{
+   @Column // no explicit column name
+   @Temporal(TemporalType.TIMESTAMP)
+   private Date someDate; // camelCase
+
+   public TargetClass2()
+   {
+   }
+
+   public TargetClass2(Date someDate, String string)
+   {
+      this.someDate = someDate;
+      this.string = string;
+   }
+
+   public Date getSomeDate()
+   {
+      return someDate;
+   }
+}


### PR DESCRIPTION
fixes OrmElf result mapping in cases when column names are implicit (introduced in #12). tests included.