### PR TITLE
fixed id rewrite in OrmWriter::updateObject, fixed OrmWriter::insertListBatched

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,12 @@
          <scope>test</scope>
       </dependency>
       <dependency>
+         <groupId>com.zaxxer</groupId>
+         <artifactId>HikariCP</artifactId>
+         <version>2.7.2</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.codehaus.btm</groupId>
          <artifactId>btm</artifactId>
          <version>2.1.4</version>
@@ -109,6 +115,12 @@
          <version>9.4-1206-jdbc42</version>
          <scope>provided</scope>
          <optional>true</optional>
+      </dependency>
+      <dependency>
+         <groupId>org.xerial</groupId>
+         <artifactId>sqlite-jdbc</artifactId>
+         <version>3.20.1</version>
+         <scope>test</scope>
       </dependency>
    </dependencies>
 

--- a/src/main/java/com/zaxxer/sansorm/internal/Introspector.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspector.java
@@ -27,7 +27,7 @@ public final class Introspector
    private static final Map<Class<?>, Introspected> descriptorMap;
 
    static {
-      descriptorMap = new ConcurrentHashMap<Class<?>, Introspected>();
+      descriptorMap = new ConcurrentHashMap<>();
    }
 
    /**

--- a/src/main/java/com/zaxxer/sansorm/internal/OrmBase.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/OrmBase.java
@@ -34,17 +34,17 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 class OrmBase
 {
-   private static Map<String, String> csvCache;
+   private static final Map<String, String> csvCache;
 
    static {
-      csvCache = new ConcurrentHashMap<String, String>();
+      csvCache = new ConcurrentHashMap<>();
    }
 
    protected OrmBase() {
       // protected constructor
    }
 
-   protected static final void populateStatementParameters(PreparedStatement stmt, Object... args) throws SQLException
+   protected static void populateStatementParameters(PreparedStatement stmt, Object... args) throws SQLException
    {
       ParameterMetaData parameterMetaData = stmt.getParameterMetaData();
       final int paramCount = parameterMetaData.getParameterCount();
@@ -59,7 +59,7 @@ class OrmBase
       }
    }
 
-   public static final <T> String getColumnsCsv(Class<T> clazz, String... tablePrefix)
+   public static <T> String getColumnsCsv(Class<T> clazz, String... tablePrefix)
    {
       String cacheKey = (tablePrefix == null || tablePrefix.length == 0 ? clazz.getName() : tablePrefix[0] + clazz.getName());
 
@@ -90,9 +90,9 @@ class OrmBase
       return columnCsv;
    }
 
-   public static final <T> String getColumnsCsvExclude(Class<T> clazz, String... excludeColumns)
+   public static <T> String getColumnsCsvExclude(Class<T> clazz, String... excludeColumns)
    {
-      Set<String> excludes = new HashSet<String>(Arrays.asList(excludeColumns));
+      Set<String> excludes = new HashSet<>(Arrays.asList(excludeColumns));
 
       Introspected introspected = Introspector.getIntrospected(clazz);
       StringBuilder sb = new StringBuilder();
@@ -116,7 +116,7 @@ class OrmBase
       return sb.deleteCharAt(sb.length() - 1).toString();
    }
 
-   protected static final Object mapSqlType(Object object, int sqlType)
+   protected static Object mapSqlType(Object object, int sqlType)
    {
       switch (sqlType) {
       case Types.TIMESTAMP:

--- a/src/main/java/com/zaxxer/sansorm/internal/OrmWriter.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/OrmWriter.java
@@ -299,12 +299,16 @@ public class OrmWriter extends OrmBase
          return;
       }
       final String idColumn = introspected.getIdColumnNames()[0];
-      final Object idExisting = checkExistingId ? introspected.get(target, idColumn) : null;
-      if (idExisting == null || Integer.valueOf(0).equals(idExisting)) {
-         try (ResultSet generatedKeys = stmt.getGeneratedKeys()) {
-            if (generatedKeys.next()) {
-               introspected.set(target, idColumn, generatedKeys.getObject(1));
-            }
+      if (checkExistingId) {
+         final Object idExisting = introspected.get(target, idColumn);
+         if (idExisting != null && (!(idExisting instanceof Integer) || (Integer) idExisting > 0)) {
+            // a bit tied to implementation but let's assume that integer id <= 0 means that it was not generated yet
+            return;
+         }
+      }
+      try (ResultSet generatedKeys = stmt.getGeneratedKeys()) {
+         if (generatedKeys.next()) {
+            introspected.set(target, idColumn, generatedKeys.getObject(1));
          }
       }
    }

--- a/src/main/java/com/zaxxer/sansorm/internal/OrmWriter.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/OrmWriter.java
@@ -89,7 +89,6 @@ public class OrmWriter extends OrmBase
                ++parameterIndex;
             }
             stmt.addBatch();
-            stmt.clearParameters();
          }
          stmt.executeBatch();
       }

--- a/src/main/java/com/zaxxer/sansorm/internal/OrmWriter.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/OrmWriter.java
@@ -32,9 +32,8 @@ import java.util.Map;
 public class OrmWriter extends OrmBase
 {
    private static final int CACHE_SIZE = Integer.getInteger("com.zaxxer.sansorm.statementCacheSize", 500);
-
-   private static Map<Introspected, String> createStatementCache;
-   private static Map<Introspected, String> updateStatementCache;
+   private static final Map<Introspected, String> createStatementCache;
+   private static final Map<Introspected, String> updateStatementCache;
 
    static {
       createStatementCache = Collections.synchronizedMap(new LinkedHashMap<Introspected, String>(CACHE_SIZE) {
@@ -74,28 +73,26 @@ public class OrmWriter extends OrmBase
 
       String[] columnNames = introspected.getInsertableColumns();
 
-      PreparedStatement stmt = createStatementForInsert(connection, introspected, columnNames);
-      int[] parameterTypes = getParameterTypes(stmt);
-
-      for (T item : iterable) {
-         int parameterIndex = 1;
-         for (String column : columnNames) {
-            int parameterType = parameterTypes[parameterIndex - 1];
-            Object object = mapSqlType(introspected.get(item, column), parameterType);
-            if (object != null && !(hasSelfJoinColumn && introspected.isSelfJoinColumn(column))) {
-               stmt.setObject(parameterIndex, object, parameterType);
+      try (PreparedStatement stmt = createStatementForInsert(connection, introspected, columnNames)) {
+         int[] parameterTypes = getParameterTypes(stmt);
+         for (T item : iterable) {
+            int parameterIndex = 1;
+            for (String column : columnNames) {
+               int parameterType = parameterTypes[parameterIndex - 1];
+               Object object = mapSqlType(introspected.get(item, column), parameterType);
+               if (object != null && !(hasSelfJoinColumn && introspected.isSelfJoinColumn(column))) {
+                  stmt.setObject(parameterIndex, object, parameterType);
+               }
+               else {
+                  stmt.setNull(parameterIndex, parameterType);
+               }
+               ++parameterIndex;
             }
-            else {
-               stmt.setNull(parameterIndex, parameterType);
-            }
-            ++parameterIndex;
+            stmt.addBatch();
+            stmt.clearParameters();
          }
-         stmt.addBatch();
-         stmt.clearParameters();
+         stmt.executeBatch();
       }
-
-      stmt.executeBatch();
-      stmt.close();
    }
 
    public static <T> void insertListNotBatched(Connection connection, Iterable<T> iterable) throws SQLException
@@ -112,56 +109,46 @@ public class OrmWriter extends OrmBase
       String[] columnNames = introspected.getInsertableColumns();
 
       // Insert
-      PreparedStatement stmt = createStatementForInsert(connection, introspected, columnNames);
-      int[] parameterTypes = getParameterTypes(stmt);
+      try (PreparedStatement stmt = createStatementForInsert(connection, introspected, columnNames)) {
+         int[] parameterTypes = getParameterTypes(stmt);
+         for (T item : iterable) {
+            int parameterIndex = 1;
+            for (String column : columnNames) {
+               int parameterType = parameterTypes[parameterIndex - 1];
+               Object object = mapSqlType(introspected.get(item, column), parameterType);
+               if (object != null && !(hasSelfJoinColumn && introspected.isSelfJoinColumn(column))) {
+                  stmt.setObject(parameterIndex, object, parameterType);
+               }
+               else {
+                  stmt.setNull(parameterIndex, parameterType);
+               }
+               ++parameterIndex;
+            }
 
-      for (T item : iterable) {
-         int parameterIndex = 1;
-         for (String column : columnNames) {
-            int parameterType = parameterTypes[parameterIndex - 1];
-            Object object = mapSqlType(introspected.get(item, column), parameterType);
-            if (object != null && !(hasSelfJoinColumn && introspected.isSelfJoinColumn(column))) {
-               stmt.setObject(parameterIndex, object, parameterType);
-            }
-            else {
-               stmt.setNull(parameterIndex, parameterType);
-            }
-            ++parameterIndex;
+            stmt.executeUpdate();
+            fillGeneratedId(item, introspected, stmt, false);
+            stmt.clearParameters();
          }
-
-         stmt.executeUpdate();
-
-         // Set auto-generated ID
-         ResultSet generatedKeys = stmt.getGeneratedKeys();
-         if (generatedKeys != null) {
-            final String idColumn = idColumnNames[0];
-            while (generatedKeys.next()) {
-               introspected.set(item, idColumn, generatedKeys.getObject(1));
-            }
-            generatedKeys.close();
-         }
-
-         stmt.clearParameters();
       }
-      stmt.close();
 
       // If there is a self-referencing column, update it with the generated IDs
       if (hasSelfJoinColumn) {
          final String selfJoinColumn = introspected.getSelfJoinColumn();
          final String idColumn = idColumnNames[0];
-         StringBuffer sql = new StringBuffer("UPDATE ").append(introspected.getTableName()).append(" SET ");
+         StringBuilder sql = new StringBuilder("UPDATE ").append(introspected.getTableName()).append(" SET ");
          sql.append(selfJoinColumn).append("=? WHERE ").append(idColumn).append("=?");
-         stmt = connection.prepareStatement(sql.toString());
-         for (T item : iterable) {
-            Object referencedItem = introspected.get(item, selfJoinColumn);
-            if (referencedItem != null) {
-               stmt.setObject(1, introspected.getActualIds(referencedItem)[0]);
-               stmt.setObject(2, introspected.getActualIds(item)[0]);
-               stmt.addBatch();
-               stmt.clearParameters();
+         try (PreparedStatement stmt = connection.prepareStatement(sql.toString())) {
+            for (T item : iterable) {
+               Object referencedItem = introspected.get(item, selfJoinColumn);
+               if (referencedItem != null) {
+                  stmt.setObject(1, introspected.getActualIds(referencedItem)[0]);
+                  stmt.setObject(2, introspected.getActualIds(item)[0]);
+                  stmt.addBatch();
+                  stmt.clearParameters();
+               }
             }
+            stmt.executeBatch();
          }
-         stmt.executeBatch();
       }
    }
 
@@ -171,9 +158,9 @@ public class OrmWriter extends OrmBase
       Introspected introspected = Introspector.getIntrospected(clazz);
       String[] columnNames = introspected.getInsertableColumns();
 
-      PreparedStatement stmt = createStatementForInsert(connection, introspected, columnNames);
-      setParamsExecuteClose(target, introspected, columnNames, stmt);
-
+      try (PreparedStatement stmt = createStatementForInsert(connection, introspected, columnNames)) {
+         setParamsExecute(target, introspected, columnNames, stmt, false);
+      }
       return target;
    }
 
@@ -183,9 +170,9 @@ public class OrmWriter extends OrmBase
       Introspected introspected = Introspector.getIntrospected(clazz);
       String[] columnNames = introspected.getUpdatableColumns();
 
-      PreparedStatement stmt = createStatementForUpdate(connection, introspected, columnNames);
-      setParamsExecuteClose(target, introspected, columnNames, stmt);
-
+      try (PreparedStatement stmt = createStatementForUpdate(connection, introspected, columnNames)) {
+         setParamsExecute(target, introspected, columnNames, stmt, true);
+      }
       return target;
    }
 
@@ -214,20 +201,9 @@ public class OrmWriter extends OrmBase
 
    public static int executeUpdate(Connection connection, String sql, Object... args) throws SQLException
    {
-      PreparedStatement stmt = null;
-      try {
-         stmt = connection.prepareStatement(sql);
-
+      try (PreparedStatement stmt = connection.prepareStatement(sql)) {
          populateStatementParameters(stmt, args);
-
-         int rc = stmt.executeUpdate();
-
-         return rc;
-      }
-      finally {
-         if (stmt != null) {
-            stmt.close();
-         }
+         return stmt.executeUpdate();
       }
    }
 
@@ -235,7 +211,7 @@ public class OrmWriter extends OrmBase
    //                      P R I V A T E   M E T H O D S
    // -----------------------------------------------------------------------
 
-   private static <T> PreparedStatement createStatementForInsert(Connection connection, Introspected introspected, String[] columns) throws SQLException
+   private static PreparedStatement createStatementForInsert(Connection connection, Introspected introspected, String[] columns) throws SQLException
    {
       String sql = createStatementCache.get(introspected);
       if (sql == null) {
@@ -261,7 +237,7 @@ public class OrmWriter extends OrmBase
       }
    }
 
-   private static <T> PreparedStatement createStatementForUpdate(Connection connection, Introspected introspected, String[] columnNames) throws SQLException
+   private static PreparedStatement createStatementForUpdate(Connection connection, Introspected introspected, String[] columnNames) throws SQLException
    {
       String sql = updateStatementCache.get(introspected);
       if (sql == null) {
@@ -287,7 +263,8 @@ public class OrmWriter extends OrmBase
       return connection.prepareStatement(sql);
    }
 
-   private static <T> void setParamsExecuteClose(T target, Introspected introspected, String[] columnNames, PreparedStatement stmt) throws SQLException
+   /** You should close stmt by yourself */
+   private static <T> void setParamsExecute(T target, Introspected introspected, String[] columnNames, PreparedStatement stmt, boolean checkExistingId) throws SQLException
    {
       int[] parameterTypes = getParameterTypes(stmt);
 
@@ -313,18 +290,23 @@ public class OrmWriter extends OrmBase
       }
 
       stmt.executeUpdate();
+      fillGeneratedId(target, introspected, stmt, checkExistingId);
+   }
 
-      if (introspected.hasGeneratedId()) {
-         // Set auto-generated ID
-         final String idColumn = introspected.getIdColumnNames()[0];
-         ResultSet generatedKeys = stmt.getGeneratedKeys();
-         if (generatedKeys != null && generatedKeys.next()) {
-            introspected.set(target, idColumn, generatedKeys.getObject(1));
-            generatedKeys.close();
+   /** Sets auto-generated ID if not set yet */
+   private static <T> void fillGeneratedId(T target, Introspected introspected, PreparedStatement stmt, boolean checkExistingId) throws SQLException {
+      if (!introspected.hasGeneratedId()) {
+         return;
+      }
+      final String idColumn = introspected.getIdColumnNames()[0];
+      final Object idExisting = checkExistingId ? introspected.get(target, idColumn) : null;
+      if (idExisting == null || Integer.valueOf(0).equals(idExisting)) {
+         try (ResultSet generatedKeys = stmt.getGeneratedKeys()) {
+            if (generatedKeys.next()) {
+               introspected.set(target, idColumn, generatedKeys.getObject(1));
+            }
          }
       }
-
-      stmt.close();
    }
 
    private static int[] getParameterTypes(PreparedStatement stmt) throws SQLException

--- a/src/test/java/org/sansorm/BaseClass.java
+++ b/src/test/java/org/sansorm/BaseClass.java
@@ -22,4 +22,8 @@ public class BaseClass
    {
       return string;
    }
+
+   public void setString(String string) {
+      this.string = string;
+   }
 }

--- a/src/test/java/org/sansorm/DateConverter.java
+++ b/src/test/java/org/sansorm/DateConverter.java
@@ -1,0 +1,18 @@
+package org.sansorm;
+
+import java.time.Instant;
+import java.util.Date;
+
+import javax.persistence.*;
+
+public class DateConverter implements AttributeConverter<Date, Number> {
+   @Override
+   public Number convertToDatabaseColumn(Date value) {
+      return value == null ? null : value.getTime();
+   }
+
+   @Override
+   public Date convertToEntityAttribute(Number value) {
+      return Date.from(Instant.ofEpochMilli(value.longValue()));
+   }
+}

--- a/src/test/java/org/sansorm/sqlite/QueryTestSQLite.java
+++ b/src/test/java/org/sansorm/sqlite/QueryTestSQLite.java
@@ -1,0 +1,146 @@
+package org.sansorm.sqlite;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.sqlite.SQLiteConfig;
+import org.sqlite.SQLiteDataSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.sansorm.SqlClosure;
+import com.zaxxer.sansorm.SqlClosureElf;
+import com.zaxxer.sansorm.TransactionElf;
+import com.zaxxer.sansorm.internal.Introspected;
+import com.zaxxer.sansorm.internal.Introspector;
+
+public class QueryTestSQLite {
+   static HikariDataSource prepareSQLiteDatasource(File db) throws IOException {
+      final SQLiteConfig sconfig = new SQLiteConfig();
+      sconfig.setJournalMode(SQLiteConfig.JournalMode.MEMORY);
+      SQLiteDataSource sds = new SQLiteDataSource(sconfig);
+      sds.setUrl(db == null
+         ? "jdbc:sqlite::memory:"
+         : "jdbc:sqlite:" + db.getAbsolutePath()
+      );
+
+      HikariConfig hconfig = new HikariConfig();
+      hconfig.setAutoCommit(false);
+      hconfig.setDataSource(sds);
+      hconfig.setMaximumPoolSize(1);
+      HikariDataSource hds = new HikariDataSource(hconfig);
+      SqlClosure.setDefaultDataSource(hds);
+      return hds;
+   }
+
+   @BeforeClass
+   public static void setup() throws Throwable
+   {
+      TransactionElf.setUserTransaction(new UserTransaction() {
+         @Override public int getStatus() throws SystemException { return Status.STATUS_NO_TRANSACTION;} // autocommit is disabled
+         @Override public void begin() throws NotSupportedException, SystemException {}
+         @Override public void commit() throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException, IllegalStateException, SystemException {}
+         @Override public void rollback() throws IllegalStateException, SecurityException, SystemException {}
+         @Override public void setRollbackOnly() throws IllegalStateException, SystemException {}
+         @Override public void setTransactionTimeout(int i) throws SystemException {}
+      });
+   }
+
+   @AfterClass
+   public static void tearDown()
+   {
+      SqlClosure.setDefaultDataSource(null);
+      TransactionElf.setUserTransaction(null);
+   }
+
+   @Test
+   public void shouldPerformCRUD() throws IOException {
+      Introspected is = Introspector.getIntrospected(TargetClassSQL.class);
+      assertTrue("test is meaningful only if class has generated id", is.hasGeneratedId());
+      assertArrayEquals(new String[]{"id"}, is.getIdColumnNames());
+
+      try (HikariDataSource ignored = prepareSQLiteDatasource(null)) {
+         SqlClosureElf.executeUpdate("CREATE TABLE TargetClassSQL ("
+            + "id integer PRIMARY KEY AUTOINCREMENT,"
+            + "string text NOT NULL,"
+            + "timestamp INTEGER"
+            + ')');
+
+         TargetClassSQL original = new TargetClassSQL("Hi", new Date(0));
+         assertNull(original.getId());
+         TargetClassSQL inserted = SqlClosureElf.insertObject(original);
+         assertSame("insertObject() sets generated id", original, inserted);
+         Integer idAfterInsert = inserted.getId();
+         assertNotNull(idAfterInsert);
+
+         TargetClassSQL selected = SqlClosureElf.objectFromClause(TargetClassSQL.class, "string = ?", "Hi");
+         assertEquals(idAfterInsert, selected.getId());
+         assertEquals("Hi", selected.getString());
+         assertEquals(0, selected.getTimestamp().getTime());
+
+         selected.setString("Hi edited");
+         TargetClassSQL updated = SqlClosureElf.updateObject(selected);
+         assertSame("updateObject() only set generated id if it was missing", selected, updated);
+         assertEquals(idAfterInsert, updated.getId());
+      }
+   }
+
+   @Test
+   public void shouldPerformCRUDAfterReconnect() throws IOException {
+      Introspected is = Introspector.getIntrospected(TargetClassSQL.class);
+      assertTrue("test is meaningful only if class has generated id", is.hasGeneratedId());
+      assertArrayEquals(new String[]{"id"}, is.getIdColumnNames());
+
+      File path = File.createTempFile("sansorm", ".db");
+      path.deleteOnExit();
+
+      Integer idAfterInsert;
+      try (HikariDataSource ignored = prepareSQLiteDatasource(path)) {
+         SqlClosureElf.executeUpdate("CREATE TABLE TargetClassSQL ("
+            + "id integer PRIMARY KEY AUTOINCREMENT,"
+            + "string text NOT NULL,"
+            + "timestamp INTEGER"
+            + ')');
+
+         TargetClassSQL original = new TargetClassSQL("Hi", new Date(0));
+         assertNull(original.getId());
+         TargetClassSQL inserted = SqlClosureElf.insertObject(original);
+         assertSame("insertObject() sets generated id", original, inserted);
+         idAfterInsert = inserted.getId();
+         assertNotNull(idAfterInsert);
+      }
+
+      // reopen database, it is important for this test
+      // then select previously inserted object and try to edit it
+      try (HikariDataSource ignored = prepareSQLiteDatasource(path)) {
+         TargetClassSQL selected = SqlClosureElf.objectFromClause(TargetClassSQL.class, "string = ?", "Hi");
+         assertEquals(idAfterInsert, selected.getId());
+         assertEquals("Hi", selected.getString());
+         assertEquals(0, selected.getTimestamp().getTime());
+
+         selected.setString("Hi edited");
+         TargetClassSQL updated = SqlClosureElf.updateObject(selected);
+         assertSame("updateObject() only set generated id if it was missing", selected, updated);
+         assertEquals(idAfterInsert, updated.getId());
+      }
+   }
+}

--- a/src/test/java/org/sansorm/sqlite/TargetClassSQL.java
+++ b/src/test/java/org/sansorm/sqlite/TargetClassSQL.java
@@ -1,0 +1,52 @@
+package org.sansorm.sqlite;
+
+import org.sansorm.DateConverter;
+
+import java.util.Date;
+
+import javax.persistence.*;
+
+@Table
+public class TargetClassSQL
+{
+   @Id
+   @GeneratedValue
+   @Column
+   private Integer id;
+
+   @Column
+   private String string;
+
+   @Column
+   @Convert(converter = DateConverter.class)
+   private Date timestamp;
+
+   public TargetClassSQL()
+   {
+   }
+
+   public TargetClassSQL(String string, Date timestamp) {
+      this.string = string;
+      this.timestamp = timestamp;
+   }
+
+   public Integer getId() {
+      return id;
+   }
+
+   public String getString() {
+      return string;
+   }
+
+   public void setString(String string) {
+      this.string = string;
+   }
+
+   public Date getTimestamp() {
+      return timestamp;
+   }
+
+   public void setTimestamp(Date timestamp) {
+      this.timestamp = timestamp;
+   }
+}


### PR DESCRIPTION
- fixed generated id rewrite in OrmWriter::updateObject
- fixed OrmWriter::insertListBatched
- removed StringBuffer in OrmWriter::insertListNotBatched
- removed string concat in OrmReader::countObjectsFromClause
- more tests including SQLite-based in addition to H2-based