### PR TITLE
 Consistent case handling with regard to @Id and @Column annotations

### DIFF
--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -501,22 +501,22 @@ public final class Introspected
          fcInfo.insertable = columnAnnotation.insertable();
          fcInfo.updatable = columnAnnotation.updatable();
       }
-      else {
+      else  {
          // If there is no Column annotation, is there a JoinColumn annotation?
          JoinColumn joinColumnAnnotation = field.getAnnotation(JoinColumn.class);
-         if (joinColumnAnnotation != null) {
-            // Is the JoinColumn a self-join?
-            if (field.getType() == clazz) {
-               fcInfo.columnName = toColumnName(joinColumnAnnotation.name());
-               selfJoinFCInfo = fcInfo;
-            }
-            else {
-               throw new RuntimeException("JoinColumn annotations can only be self-referencing: " + field.getType().getCanonicalName() + " != "
-                     + clazz.getCanonicalName());
-            }
+         if ((joinColumnAnnotation != null)) {
+            processJoinColumnAnnotation(fcInfo, field, joinColumnAnnotation);
          }
          else {
-            fcInfo.columnName = field.getName().toLowerCase();
+            // Is there a @Id annotation?
+            Id idAnnotation = field.getAnnotation(Id.class);
+            if (idAnnotation != null) {
+               // @Id without @Column annotation, so preserve case of property name.
+               fcInfo.columnName = field.getName();
+            }
+            else {
+               fcInfo.columnName = field.getName().toLowerCase();
+            }
          }
       }
 
@@ -525,6 +525,18 @@ public final class Introspected
          String keyName = !(fcInfo.columnName.startsWith("\"") && fcInfo.columnName.endsWith("\"")) ? fcInfo.columnName : fcInfo.columnName.substring(1, fcInfo.columnName.length() - 1);
          columnToField.put(keyName, fcInfo);
          delimitedColumnToField.put(fcInfo.columnName, fcInfo);
+      }
+   }
+
+   private void processJoinColumnAnnotation(FieldColumnInfo fcInfo, Field field, JoinColumn joinColumnAnnotation) {
+      // Is the JoinColumn a self-join?
+      if (field.getType() == clazz) {
+         fcInfo.columnName = toColumnName(joinColumnAnnotation.name());
+         selfJoinFCInfo = fcInfo;
+      }
+      else {
+         throw new RuntimeException("JoinColumn annotations can only be self-referencing: " + field.getType().getCanonicalName() + " != "
+               + clazz.getCanonicalName());
       }
    }
 

--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -488,13 +488,13 @@ public final class Introspected
 
       Column columnAnnotation = field.getAnnotation(Column.class);
       if (columnAnnotation != null) {
-         processColumnAnnotation(fcInfo, field, columnAnnotation);
+         processColumnAnnotation(fcInfo, columnAnnotation);
       }
       else  {
          // If there is no Column annotation, is there a JoinColumn annotation?
          JoinColumn joinColumnAnnotation = field.getAnnotation(JoinColumn.class);
          if (joinColumnAnnotation != null) {
-            processJoinColumnAnnotation(fcInfo, field, joinColumnAnnotation);
+            processJoinColumnAnnotation(fcInfo, joinColumnAnnotation);
          }
          else {
             Id idAnnotation = field.getAnnotation(Id.class);
@@ -517,10 +517,10 @@ public final class Introspected
       }
    }
 
-   private void processColumnAnnotation(FieldColumnInfo fcInfo, Field field, Column columnAnnotation) {
+   private void processColumnAnnotation(FieldColumnInfo fcInfo, Column columnAnnotation) {
       String columnName = columnAnnotation.name();
       fcInfo.columnName = columnName.isEmpty()
-         ? field.getName() // as per documentation, empty name in Column "defaults to the property or field name"
+         ? fcInfo.field.getName() // as per documentation, empty name in Column "defaults to the property or field name"
          : toColumnName(columnName);
 
       String columnTableName = columnAnnotation.table();
@@ -532,14 +532,14 @@ public final class Introspected
       fcInfo.updatable = columnAnnotation.updatable();
    }
 
-   private void processJoinColumnAnnotation(FieldColumnInfo fcInfo, Field field, JoinColumn joinColumnAnnotation) {
+   private void processJoinColumnAnnotation(FieldColumnInfo fcInfo, JoinColumn joinColumnAnnotation) {
       // Is the JoinColumn a self-join?
-      if (field.getType() == clazz) {
+      if (fcInfo.field.getType() == clazz) {
          fcInfo.columnName = toColumnName(joinColumnAnnotation.name());
          selfJoinFCInfo = fcInfo;
       }
       else {
-         throw new RuntimeException("JoinColumn annotations can only be self-referencing: " + field.getType().getCanonicalName() + " != "
+         throw new RuntimeException("JoinColumn annotations can only be self-referencing: " + fcInfo.field.getType().getCanonicalName() + " != "
                + clazz.getCanonicalName());
       }
    }

--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -488,13 +488,13 @@ public final class Introspected
 
       Column columnAnnotation = field.getAnnotation(Column.class);
       if (columnAnnotation != null) {
-         processColumnAnnotation(fcInfo, columnAnnotation);
+         processColumnAnnotation(fcInfo);
       }
       else  {
          // If there is no Column annotation, is there a JoinColumn annotation?
          JoinColumn joinColumnAnnotation = field.getAnnotation(JoinColumn.class);
          if (joinColumnAnnotation != null) {
-            processJoinColumnAnnotation(fcInfo, joinColumnAnnotation);
+            processJoinColumnAnnotation(fcInfo);
          }
          else {
             Id idAnnotation = field.getAnnotation(Id.class);
@@ -517,7 +517,8 @@ public final class Introspected
       }
    }
 
-   private void processColumnAnnotation(FieldColumnInfo fcInfo, Column columnAnnotation) {
+   private void processColumnAnnotation(FieldColumnInfo fcInfo) {
+      Column columnAnnotation = fcInfo.field.getAnnotation(Column.class);
       String columnName = columnAnnotation.name();
       fcInfo.columnName = columnName.isEmpty()
          ? fcInfo.field.getName() // as per documentation, empty name in Column "defaults to the property or field name"
@@ -532,7 +533,8 @@ public final class Introspected
       fcInfo.updatable = columnAnnotation.updatable();
    }
 
-   private void processJoinColumnAnnotation(FieldColumnInfo fcInfo, JoinColumn joinColumnAnnotation) {
+   private void processJoinColumnAnnotation(FieldColumnInfo fcInfo) {
+      JoinColumn joinColumnAnnotation = fcInfo.field.getAnnotation(JoinColumn.class);
       // Is the JoinColumn a self-join?
       if (fcInfo.field.getType() == clazz) {
          fcInfo.columnName = toColumnName(joinColumnAnnotation.name());

--- a/src/test/java/com/zaxxer/sansorm/internal/CaseSensitiveDatabasesTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/CaseSensitiveDatabasesTest.java
@@ -283,12 +283,10 @@ public class CaseSensitiveDatabasesTest {
       assertTrue(introspected.isUpdatableColumn("DELIMITED_FIELD_NAME"));
    }
 
-   // CLARIFY Inconsistent behaviour? This behaviour is not restricted to @Id fields. Same behaviour with @Column only annotated fields.
    @Test
    public void getIdColumnNames() {
       class TestClass {
-         @Id
-         @Column(name = "\"ID\"")
+         @Id @Column(name = "\"ID\"")
          String id;
          @Id
          String Id2;
@@ -303,10 +301,43 @@ public class CaseSensitiveDatabasesTest {
       String[] idColumnNames = introspected.getIdColumnNames();
       assertTrue(idColumnNames.length == 5);
       assertEquals("\"ID\"", idColumnNames[0]);
-      assertEquals("id2", idColumnNames[1]);
+      assertEquals("Id2", idColumnNames[1]);
       assertEquals("Id3", idColumnNames[2]);
       assertEquals("id4", idColumnNames[3]);
       assertEquals("Id5", idColumnNames[4]);
+   }
+
+   @Test
+   public void constistentIdSupport() {
+      class TestClass {
+         @Id
+         String Id;
+      }
+      Introspected introspected = new Introspected(TestClass.class);
+      String[] idColumnNames = introspected.getIdColumnNames();
+      assertEquals("Id", idColumnNames[0]);
+   }
+
+   @Test
+   public void getColumnsSansIds() {
+      class TestClass {
+         @Column(name = "\"COL\"")
+         String col;
+         @Column
+         String Col2;
+         @Column(name = "Col3")
+         String Col3;
+         @Column(name = "")
+         String Col4;
+      }
+      Introspected introspected = new Introspected(TestClass.class);
+
+      String[] columnsSansIds = introspected.getColumnsSansIds();
+      assertTrue(columnsSansIds.length == 4);
+      assertEquals("\"COL\"", columnsSansIds[0]);
+      assertEquals("Col2", columnsSansIds[1]); // differs from getIdColumnNames()
+      assertEquals("col3", columnsSansIds[2]);
+      assertEquals("Col4", columnsSansIds[3]);
    }
 
    @Test


### PR DESCRIPTION
@brettwooldridge The PR fixes the inconsistent case handling of `@Id` annotated fields which have not also a `@Column` annotation. Now CaseSensitiveDatabasesTest#getIdColumnNames() behaves like CaseSensitiveDatabasesTest#getColumnsSansIds().