### PR TITLE
Pre-calculation of column infos completed.

### DIFF
--- a/src/main/java/com/zaxxer/sansorm/OrmElf.java
+++ b/src/main/java/com/zaxxer/sansorm/OrmElf.java
@@ -173,7 +173,7 @@ public final class OrmElf
     *
     * @param resultSet a {@link ResultSet}
     * @param target the target object to set values on
-    * @param ignoredColumns the columns in the result set to ignore.
+    * @param ignoredColumns the columns in the result set to ignore. Case as in name element or property name.
     * @param <T> the class template
     * @return the populated object
     * @throws SQLException if a {@link SQLException} occurs

--- a/src/main/java/com/zaxxer/sansorm/internal/FieldColumnInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/FieldColumnInfo.java
@@ -1,0 +1,259 @@
+package com.zaxxer.sansorm.internal;
+
+import javax.persistence.*;
+import java.lang.reflect.Field;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Column information about a field
+ */
+final class FieldColumnInfo
+{
+   private final String propertyName;
+   private boolean isDelimited;
+   /** defaults to true */
+   boolean updatable;
+   /** defaults to true */
+   boolean insertable;
+   private String columnName;
+   /** name without delimiter: lower cased; delimited name: name as is with delimiters */
+   String columnTableName = "";
+   final Field field;
+   Class<?> fieldType;
+   private final Class<?> clazz;
+   EnumType enumType;
+   Map<Object, Object> enumConstants;
+   private AttributeConverter converter;
+   private String caseSensitiveColumnName;
+   boolean isGeneratedId;
+   boolean isIdField;
+   private boolean isJoinColumn;
+   boolean isTransient;
+   private boolean isEnumerated;
+   private boolean isColumnAnnotated;
+   private String delimitedFieldName;
+   private String fullyQualifiedDelimitedFieldName;
+
+   public FieldColumnInfo(Field field, Class<?> clazz) {
+      this.field = field;
+      this.clazz = clazz;
+      propertyName = field.getName();
+      setFieldType();
+      extractAnnotations();
+      processFieldAnnotations();
+      fullyQualifiedDelimitedFieldName =
+         columnTableName.isEmpty() ? delimitedFieldName : columnTableName + "." + delimitedFieldName;
+   }
+
+   private void setFieldType() {
+      this.fieldType = field.getType();
+
+      // remap safe conversions
+      if (fieldType == Date.class) {
+         fieldType = Timestamp.class;
+      }
+      else if (fieldType == int.class) {
+         fieldType = Integer.class;
+      }
+      else if (fieldType == long.class) {
+         fieldType = Long.class;
+      }
+   }
+
+   private void processFieldAnnotations()
+   {
+      if (isColumnAnnotated) {
+         processColumnAnnotation();
+      }
+      else  {
+         if (isJoinColumn) {
+            processJoinColumnAnnotation();
+         }
+         else {
+            if (isIdField) {
+               // @Id without @Column annotation, so preserve case of property name.
+               setColumnName(field.getName());
+            }
+            else {
+               // CLARIFY Dead code? Never reached by tests.
+               setColumnName(field.getName());
+            }
+         }
+      }
+      processConvertAnnotation();
+   }
+
+   private void setCaseSensitiveColumnName(String columnName) {
+      if (!isTransient) {
+         caseSensitiveColumnName =
+            isNotDelimited(field.getName())
+               ? field.getName()
+               : field.getName().substring(1, field.getName().length() - 1);
+      }
+   }
+
+   private void extractAnnotations() {
+      Id idAnnotation = field.getAnnotation(Id.class);
+      if (idAnnotation != null) {
+         isIdField = true;
+         GeneratedValue generatedAnnotation = field.getAnnotation(GeneratedValue.class);
+         isGeneratedId = (generatedAnnotation != null);
+      }
+
+      Enumerated enumAnnotation = field.getAnnotation(Enumerated.class);
+      if (enumAnnotation != null) {
+         isEnumerated = true;
+         this.setEnumConstants(enumAnnotation.value());
+      }
+      JoinColumn joinColumnAnnotation = field.getAnnotation(JoinColumn.class);
+      if (joinColumnAnnotation != null) {
+         isJoinColumn = true;
+      }
+      Transient transientAnnotation = field.getAnnotation(Transient.class);
+      if (transientAnnotation != null) {
+         isTransient = true;
+      }
+      Column columnAnnotation = field.getAnnotation(Column.class);
+      if (columnAnnotation != null) {
+         isColumnAnnotated = true;
+      }
+   }
+
+   private void processConvertAnnotation()  {
+      Convert convertAnnotation = field.getAnnotation(Convert.class);
+      if (convertAnnotation != null) {
+         Class converterClass = convertAnnotation.converter();
+         if (!AttributeConverter.class.isAssignableFrom(converterClass)) {
+            throw new RuntimeException(
+               "Convert annotation only supports converters implementing AttributeConverter");
+         }
+         try {
+            setConverter((AttributeConverter)converterClass.newInstance());
+         }
+         catch (InstantiationException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+         }
+      }
+   }
+
+   /**
+    * Processes &#64;Column annotated fields.
+    */
+   private void processColumnAnnotation() {
+      Column columnAnnotation = field.getAnnotation(Column.class);
+      String columnName = columnAnnotation.name();
+      setColumnName(columnName);
+
+      this.columnTableName = columnAnnotation.table();
+      insertable = columnAnnotation.insertable();
+      updatable = columnAnnotation.updatable();
+   }
+
+   private void processJoinColumnAnnotation() {
+      JoinColumn joinColumnAnnotation = field.getAnnotation(JoinColumn.class);
+      // Is the JoinColumn a self-join?
+      if (field.getType() == clazz) {
+         setColumnName(joinColumnAnnotation.name());
+      }
+      else {
+         throw new RuntimeException("JoinColumn annotations can only be self-referencing: " + field.getType().getCanonicalName() + " != "
+            + clazz.getCanonicalName());
+      }
+   }
+
+   private boolean isNotDelimited(String columnName) {
+      return !columnName.startsWith("\"") || !columnName.endsWith("\"");
+   }
+
+   private void setColumnName(String columnName) {
+      columnName = columnName.isEmpty()
+         ? field.getName() // as per EJB specification, empty name in Column "defaults to the property or field name"
+         : columnName;
+      if (isNotDelimited(columnName)) {
+         this.columnName = columnName.toLowerCase();
+         caseSensitiveColumnName = columnName;
+         delimitedFieldName = columnName;
+      }
+      else {
+         this.columnName = columnName.substring(1, columnName.length() - 1);
+         caseSensitiveColumnName = this.columnName;
+         delimitedFieldName = columnName;
+         isDelimited = true;
+      }
+   }
+
+   <T extends Enum<?>> void setEnumConstants(EnumType type)
+   {
+      enumType = type;
+      enumConstants = new HashMap<>();
+      @SuppressWarnings("unchecked")
+      T[] enums = (T[]) field.getType().getEnumConstants();
+      for (T enumConst : enums) {
+         Object key = (type == EnumType.ORDINAL ? enumConst.ordinal() : enumConst.name());
+         enumConstants.put(key, enumConst);
+      }
+   }
+
+   @Override
+   public String toString()
+   {
+      return field.getName() + "->" + getColumnName();
+   }
+
+   public void setConverter(AttributeConverter converter) {
+      this.converter = converter;
+   }
+
+   public AttributeConverter getConverter() {
+      return converter;
+   }
+
+   boolean isSelfJoinField() {
+      return isJoinColumn && field.getType() == clazz;
+   }
+
+   /** name without delimiter: lower cased; delimited name: name as is without delimiters */
+   public String getColumnName() {
+      return columnName;
+   }
+
+   public String getPropertyName() {
+      return propertyName;
+   }
+
+   /**
+    * @return If set &#64;Column name value else property name. In case of delimited fields without delimiters.
+    */
+   public String getCaseSensitiveColumnName() {
+      return caseSensitiveColumnName;
+   }
+
+   /**
+    *
+    * @return case sensitive column name. In case of delimited fields surrounded by delimiters.
+    */
+   public String getDelimitedColumnName() {
+      return delimitedFieldName;
+   }
+
+   /**
+    *
+    * @param tablePrefix Ignored when field has a non empty table element.
+    */
+   public String getFullyQualifiedDelimitedFieldName(String ... tablePrefix) {
+      return columnTableName.isEmpty() && tablePrefix.length > 0
+         ? tablePrefix[0] + "." + fullyQualifiedDelimitedFieldName
+         : fullyQualifiedDelimitedFieldName;
+   }
+
+   public boolean isDelimited() {
+      return isDelimited;
+   }
+
+   public boolean isEnumerated() {
+      return isEnumerated;
+   }
+}

--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -178,6 +178,9 @@ public final class Introspected
    {
       FieldColumnInfo fcInfo = columnToField.get(columnName);
       if (fcInfo == null) {
+         fcInfo = delimitedColumnToField.get(columnName);
+      }
+      if (fcInfo == null) {
          throw new RuntimeException("Cannot find field mapped to column " + columnName + " on type " + target.getClass().getCanonicalName());
       }
 
@@ -318,6 +321,11 @@ public final class Introspected
       List<String> columns = new LinkedList<>();
       if (hasGeneratedId()) {
          columns.addAll(Arrays.asList(columnsSansIds));
+         for (Entry<String, FieldColumnInfo> entry : columnToField.entrySet()) {
+            if (!isInsertableColumn(entry.getKey())) {
+               columns.remove(entry.getValue().columnName);
+            }
+         }
       }
       else {
          getDelimitedInsertableColumns(columns);
@@ -349,6 +357,11 @@ public final class Introspected
       List<String> columns = new LinkedList<>();
       if (hasGeneratedId()) {
          columns.addAll(Arrays.asList(columnsSansIds));
+         for (Entry<String, FieldColumnInfo> entry : columnToField.entrySet()) {
+            if (!isUpdatableColumn(entry.getKey())) {
+               columns.remove(entry.getValue().columnName);
+            }
+         }
       }
       else {
          getDelimitedUpdatableColumns(columns);

--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -178,9 +178,6 @@ public final class Introspected
    {
       FieldColumnInfo fcInfo = columnToField.get(columnName);
       if (fcInfo == null) {
-         fcInfo = delimitedColumnToField.get(columnName);
-      }
-      if (fcInfo == null) {
          throw new RuntimeException("Cannot find field mapped to column " + columnName + " on type " + target.getClass().getCanonicalName());
       }
 
@@ -321,11 +318,6 @@ public final class Introspected
       List<String> columns = new LinkedList<>();
       if (hasGeneratedId()) {
          columns.addAll(Arrays.asList(columnsSansIds));
-         for (Entry<String, FieldColumnInfo> entry : columnToField.entrySet()) {
-            if (!isInsertableColumn(entry.getKey())) {
-               columns.remove(entry.getValue().columnName);
-            }
-         }
       }
       else {
          getDelimitedInsertableColumns(columns);
@@ -357,11 +349,6 @@ public final class Introspected
       List<String> columns = new LinkedList<>();
       if (hasGeneratedId()) {
          columns.addAll(Arrays.asList(columnsSansIds));
-         for (Entry<String, FieldColumnInfo> entry : columnToField.entrySet()) {
-            if (!isUpdatableColumn(entry.getKey())) {
-               columns.remove(entry.getValue().columnName);
-            }
-         }
       }
       else {
          getDelimitedUpdatableColumns(columns);

--- a/src/main/java/com/zaxxer/sansorm/internal/OrmBase.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/OrmBase.java
@@ -59,28 +59,21 @@ class OrmBase
       }
    }
 
+   /**
+    *
+    * @see #getColumnsCsvExclude(Class, String...)
+    */
    public static <T> String getColumnsCsv(Class<T> clazz, String... tablePrefix)
    {
       String cacheKey = (tablePrefix == null || tablePrefix.length == 0 ? clazz.getName() : tablePrefix[0] + clazz.getName());
-
       String columnCsv = csvCache.get(cacheKey);
       if (columnCsv == null) {
          Introspected introspected = Introspector.getIntrospected(clazz);
          StringBuilder sb = new StringBuilder();
-         String[] columnNames = introspected.getColumnNames();
-         String[] columnTableNames = introspected.getColumnTableNames();
-         for (int i = 0; i < columnNames.length; i++) {
-            String column = columnNames[i];
-            String columnTableName = columnTableNames[i];
 
-            if (columnTableName != null) {
-               sb.append(columnTableName).append('.');
-            }
-            else if (tablePrefix.length > 0) {
-               sb.append(tablePrefix[0]).append('.');
-            }
-
-            sb.append(column).append(',');
+         FieldColumnInfo[] selectableFields = introspected.getSelectableFcInfos();
+         for (FieldColumnInfo selectableField : selectableFields) {
+            sb.append(selectableField.getFullyQualifiedDelimitedFieldName(tablePrefix)).append(',');
          }
 
          columnCsv = sb.deleteCharAt(sb.length() - 1).toString();
@@ -91,34 +84,20 @@ class OrmBase
    }
 
    /**
-    *
-    * @param excludeColumns In case of delimited column names provide name without delimiters.
-    * @return comma separated column names. In case of delimited column names the column names are surrounded by delimiters.
+    * @param excludeColumns Case as in name element or property name. In case of delimited column names provide name without delimiters.
+    * @return Selectable columns. Comma separated. In case of delimited column names the column names are surrounded by delimiters.
     */
    public static <T> String getColumnsCsvExclude(Class<T> clazz, String... excludeColumns)
    {
       Set<String> excludes = new HashSet<>(Arrays.asList(excludeColumns));
-
       Introspected introspected = Introspector.getIntrospected(clazz);
       StringBuilder sb = new StringBuilder();
-      String[] delimitedColumnNames = introspected.getColumnNames();
-      String[] columnTableNames = introspected.getColumnTableNames();
-      for (int i = 0; i < delimitedColumnNames.length; i++) {
-         String delimitedColumn = delimitedColumnNames[i];
-         boolean isDelimited = delimitedColumn.startsWith("\"") && delimitedColumn.endsWith("\"");
-         String column = !isDelimited  ? delimitedColumn
-                                       : delimitedColumn.substring(1, delimitedColumn.length() - 1);
-         if (excludes.contains(column)) {
-            continue;
+
+      FieldColumnInfo[] selectableFields = introspected.getSelectableFcInfos();
+      for (FieldColumnInfo selectableField : selectableFields) {
+         if (!excludes.contains(selectableField.getCaseSensitiveColumnName())) {
+            sb.append(selectableField.getFullyQualifiedDelimitedFieldName()).append(',');
          }
-
-         String columnTableName = columnTableNames[i];
-
-         if (columnTableName != null) {
-            sb.append(columnTableName).append('.');
-         }
-
-         sb.append(delimitedColumn).append(',');
       }
 
       return sb.deleteCharAt(sb.length() - 1).toString();

--- a/src/main/java/com/zaxxer/sansorm/internal/OrmReader.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/OrmReader.java
@@ -98,14 +98,13 @@ public class OrmReader extends OrmBase
                if (columnValue == null) {
                   continue;
                }
-
                String columnName = columnNames[column - 1];
-
-               if (hasJoinColumns && introspected.isSelfJoinColumn(columnName)) {
+               FieldColumnInfo fcInfo = introspected.getFieldColumnInfo(columnName);
+               if (fcInfo.isSelfJoinField()) {
                   deferredSelfJoinFkMap.put(target, columnValue);
                }
                else {
-                  introspected.set(target, columnName, columnValue);
+                  introspected.set(target, fcInfo, columnValue);
                }
             }
 
@@ -119,7 +118,7 @@ public class OrmReader extends OrmBase
 
          if (hasJoinColumns) {
             // set the self join object instances based on the foreign key ids...
-            String idColumn = introspected.getSelfJoinColumn();
+            FieldColumnInfo idColumn = introspected.getSelfJoinColumnInfo();
             for (Entry<T, Object> entry : deferredSelfJoinFkMap.entrySet()) {
                T value = idToTargetMap.get(entry.getValue());
                if (value != null) {
@@ -183,11 +182,10 @@ public class OrmReader extends OrmBase
          if (columnValue == null) {
             continue;
          }
-         introspected.set(target, columnName, columnValue);
+         introspected.set(target, introspected.getFieldColumnInfo(columnName), columnValue);
       }
       return target;
    }
-
 
    public static <T> T objectById(Connection connection, Class<T> clazz, Object... args) throws SQLException
    {

--- a/src/test/java/com/zaxxer/sansorm/OrmElfTest.java
+++ b/src/test/java/com/zaxxer/sansorm/OrmElfTest.java
@@ -66,10 +66,10 @@ public class OrmElfTest {
             };
          }
       };
-      TestClass obj = OrmElf.updateObject(con, new TestClass(), "field_1", "\"Field_3\"");
-      assertEquals("UPDATE Test_Class SET field4=?,FIELD_2=? WHERE id=?", fetchedSql[0]);
-      assertEquals("field4", idxToValue.get(1));
-      assertEquals("field2", idxToValue.get(2));
+      TestClass obj = OrmElf.updateObject(con, new TestClass(), "field_1", "Field_3");
+      assertEquals("UPDATE Test_Class SET FIELD_2=?,field4=? WHERE id=?", fetchedSql[0]);
+      assertEquals("field2", idxToValue.get(1));
+      assertEquals("field4", idxToValue.get(2));
       assertEquals("xyz", idxToValue.get(3));
    }
 

--- a/src/test/java/com/zaxxer/sansorm/internal/CaseSensitiveDatabasesTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/CaseSensitiveDatabasesTest.java
@@ -3,6 +3,7 @@ package com.zaxxer.sansorm.internal;
 import com.zaxxer.sansorm.OrmElf;
 import com.zaxxer.sansorm.SansOrm;
 import com.zaxxer.sansorm.SqlClosureElf;
+import org.h2.jdbcx.JdbcDataSource;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.sansorm.TestUtils;
@@ -115,7 +116,8 @@ public class CaseSensitiveDatabasesTest {
          String defaultCase;
       }
       String cols = OrmReader.getColumnsCsv(TestClass.class);
-      assertEquals("Default_Case,\"Delimited Field Name\"", cols);
+      // Preserve field order!!!
+      assertEquals("\"Delimited Field Name\",Default_Case", cols);
    }
 
    @Test
@@ -127,15 +129,18 @@ public class CaseSensitiveDatabasesTest {
          String defaultCase;
       }
       String cols = OrmReader.getColumnsCsv(TestClass.class);
-      assertEquals("Default_Case_Table.Default_Case,\"Delimited table name\".\"Delimited Field Name\"", cols);
+      // Preserve field order!!!
+      assertEquals(cols, "\"Delimited table name\".\"Delimited Field Name\",Default_Case_Table.Default_Case");
    }
 
    @Test
    public void getColumnsCsvExclude() {
       String cols = OrmBase.getColumnsCsvExclude(CaseSensitiveDatabasesClass.class, "Delimited Field Name");
-      assertEquals("Default_Case,Id", cols);
+      // Preserve field order!!!
+      assertEquals("Id,Default_Case", cols);
       cols = OrmBase.getColumnsCsvExclude(CaseSensitiveDatabasesClass.class, "Default_Case");
-      assertEquals("\"Delimited Field Name\",Id", cols);
+      // Preserve field order!!!
+      assertEquals("Id,\"Delimited Field Name\"", cols);
    }
 
    @Test
@@ -149,7 +154,8 @@ public class CaseSensitiveDatabasesTest {
          String excluded;
       }
       String cols = OrmBase.getColumnsCsvExclude(TestClass.class, "excluded");
-      assertEquals("\"DELIMITED_TABLE_NAME\".Default_Case,Default_Table_Name.\"Delimited Field Name\"", cols);
+      // Preserve field order!!!
+      assertEquals("Default_Table_Name.\"Delimited Field Name\",\"DELIMITED_TABLE_NAME\".Default_Case", cols);
    }
 
    @Test
@@ -194,7 +200,7 @@ public class CaseSensitiveDatabasesTest {
       }
       Introspected introspected = Introspector.getIntrospected(TestClass.class);
       String[] cols = introspected.getInsertableColumns();
-      assertArrayEquals(new String[]{"Default_Case", "\"Delimited Field Name\""}, cols);
+      assertArrayEquals(new String[]{"\"Delimited Field Name\"", "Default_Case"}, cols);
    }
 
    @Test
@@ -210,7 +216,7 @@ public class CaseSensitiveDatabasesTest {
       }
       Introspected introspected = Introspector.getIntrospected(TestClass.class);
       String[] cols = introspected.getInsertableColumns();
-      assertArrayEquals(new String[]{"Default_Case", "\"Delimited Field Name\"", "Id"}, cols);
+      assertArrayEquals(new String[]{"Id", "\"Delimited Field Name\"", "Default_Case"}, cols);
    }
 
    @Test
@@ -316,7 +322,7 @@ public class CaseSensitiveDatabasesTest {
       }
       Introspected introspected = Introspector.getIntrospected(TestClass.class);
       String[] cols = introspected.getInsertableColumns();
-      assertArrayEquals(new String[]{"Default_Case", "\"Delimited Field Name\""}, cols);
+      assertArrayEquals(new String[]{"\"Delimited Field Name\"", "Default_Case"}, cols);
    }
 
    /**
@@ -335,7 +341,7 @@ public class CaseSensitiveDatabasesTest {
       }
       Introspected introspected = Introspector.getIntrospected(TestClass.class);
       String[] cols = introspected.getInsertableColumns();
-      assertArrayEquals(new String[]{"Default_Case", "\"Delimited Field Name\""}, cols);
+      assertArrayEquals(new String[]{"\"Delimited Field Name\"", "Default_Case"}, cols);
    }
 
    @Test
@@ -351,7 +357,7 @@ public class CaseSensitiveDatabasesTest {
       }
       Introspected introspected = Introspector.getIntrospected(TestClass.class);
       String[] cols = introspected.getUpdatableColumns();
-      assertArrayEquals(new String[]{"Default_Case", "\"Delimited Field Name\"", "Id"}, cols);
+      assertArrayEquals(new String[]{"Id", "\"Delimited Field Name\"", "Default_Case"}, cols);
    }
 
    @Test
@@ -367,7 +373,7 @@ public class CaseSensitiveDatabasesTest {
       }
       Introspected introspected = Introspector.getIntrospected(TestClass.class);
       String[] cols = introspected.getUpdatableColumns();
-      assertArrayEquals(new String[]{"Default_Case", "\"Delimited Field Name\""}, cols);
+      assertArrayEquals(new String[]{"\"Delimited Field Name\"", "Default_Case"}, cols);
    }
 
    @Test
@@ -383,7 +389,7 @@ public class CaseSensitiveDatabasesTest {
       }
       Introspected introspected = Introspector.getIntrospected(TestClass.class);
       String[] cols = introspected.getUpdatableColumns();
-      assertArrayEquals(new String[]{"Default_Case", "\"Delimited Field Name\""}, cols);
+      assertArrayEquals(new String[]{"\"Delimited Field Name\"", "Default_Case"}, cols);
    }
 
    @Test
@@ -499,7 +505,7 @@ public class CaseSensitiveDatabasesTest {
          }
       };
       TestClass obj = OrmWriter.insertObject(con, new TestClass());
-      assertEquals("INSERT INTO Test_Class(Default_Case,\"Delimited Field Name\") VALUES (?,?)", fetchedSql[0]);
+      assertEquals("INSERT INTO Test_Class(\"Delimited Field Name\",Default_Case) VALUES (?,?)", fetchedSql[0]);
       assertEquals(defaultCaseValue, obj.defaultCase);
       assertEquals(delimitedFieldValue, obj.delimitedFieldName);
    }
@@ -555,7 +561,7 @@ public class CaseSensitiveDatabasesTest {
          }
       };
       TestClass obj = OrmWriter.insertObject(con, new TestClass());
-      assertEquals("INSERT INTO Test_Class(Default_Case,\"Delimited field name\") VALUES (?,?)", fetchedSql[0]);
+      assertEquals("INSERT INTO Test_Class(\"Delimited field name\",Default_Case) VALUES (?,?)", fetchedSql[0]);
       assertEquals(defaultCaseValue, obj.defaultCase);
       assertEquals(delimitedFieldValue, obj.delimitedFieldName);
       assertEquals("123", obj.id);
@@ -624,7 +630,8 @@ public class CaseSensitiveDatabasesTest {
          }
       };
       CaseSensitiveDatabasesClass obj = OrmReader.objectById(con, CaseSensitiveDatabasesClass.class, "xyz");
-      assertEquals("SELECT Test_Class.Default_Case,Test_Class.\"Delimited Field Name\",Test_Class.Id FROM Test_Class Test_Class WHERE  Id=?", fetchedSql[0]);
+      // Preserve field order!!!
+      assertEquals("SELECT Test_Class.Id,Test_Class.\"Delimited Field Name\",Test_Class.Default_Case FROM Test_Class Test_Class WHERE  Id=?", fetchedSql[0]);
       assertEquals(idValue, obj.getId());
       assertEquals(defaultCaseValue, obj.getDefaultCase());
       assertEquals(delimitedFieldValue, obj.getDelimitedFieldName());
@@ -664,9 +671,127 @@ public class CaseSensitiveDatabasesTest {
          }
       };
       TestClass obj = OrmWriter.updateObject(con, new TestClass());
-      assertEquals("UPDATE Test_Class SET Default_Case=?,\"Delimited Field Name\"=?", fetchedSql[0]);
+      assertEquals("UPDATE Test_Class SET \"Delimited Field Name\"=?,Default_Case=?", fetchedSql[0]);
       assertEquals(defaultCaseValue, obj.defaultCase);
       assertEquals(upperCaseValue, obj.delimitedFieldName);
+   }
+
+   @Test
+   public void updateObjectGeneratedId() throws SQLException {
+      String upperCaseValue = "delimited field value";
+      String defaultCaseValue = "default case value";
+      @Table(name = "Test_Class")
+      class TestClass {
+         @Id @GeneratedValue
+         String id;
+         @Column(name = "\"Delimited Field Name\"")
+         String delimitedFieldName = upperCaseValue;
+         @Column(name = "Default_Case")
+         String defaultCase = defaultCaseValue;
+      }
+      final String[] fetchedSql = new String[1];
+      DummyConnection con = new DummyConnection() {
+         @Override
+         public PreparedStatement prepareStatement(String sql) {
+            fetchedSql[0] = sql;
+            return new DummyStatement() {
+               @Override
+               public ParameterMetaData getParameterMetaData() {
+                  return new DummyParameterMetaData() {
+                     @Override
+                     public int getParameterCount() {
+                        return CaseSensitiveDatabasesTest.this.getParameterCount(fetchedSql[0]);
+                     }
+                     @Override
+                     public int getParameterType(int param) {
+                        return Types.VARCHAR;
+                     }
+                  };
+               }
+
+               @Override
+               public ResultSet getGeneratedKeys() throws SQLException {
+                  return new DummyResultSet() {
+                     @Override
+                     public boolean next() throws SQLException {
+                        return true;
+                     }
+
+                     @Override
+                     public Object getObject(int columnIndex) throws SQLException {
+                        return "123";
+                     }
+                  };
+               }
+            };
+         }
+      };
+      TestClass obj = OrmWriter.updateObject(con, new TestClass());
+      assertEquals("UPDATE Test_Class SET \"Delimited Field Name\"=?,Default_Case=? WHERE id=?", fetchedSql[0]);
+      assertEquals(defaultCaseValue, obj.defaultCase);
+      assertEquals(upperCaseValue, obj.delimitedFieldName);
+   }
+
+   @Test
+   public void updateObjectGeneratedDelimitedId() throws SQLException {
+      String upperCaseValue = "delimited field value";
+      int defaultCaseValue = 1;
+      @Table(name = "Test_Class")
+      class TestClass {
+         @Id @GeneratedValue @Column(name = "\"Id\"")
+         int id;
+         @Column(name = "\"Delimited Field Name\"")
+         String delimitedFieldName = upperCaseValue;
+         @Column(name = "Default_Case")
+         int myInt = defaultCaseValue;
+         @Column
+         int myInt2 = defaultCaseValue;
+      }
+      final String[] fetchedSql = new String[1];
+      DummyConnection con = new DummyConnection() {
+         @Override
+         public PreparedStatement prepareStatement(String sql) {
+            fetchedSql[0] = sql;
+            return new DummyStatement() {
+               @Override
+               public ParameterMetaData getParameterMetaData() {
+                  return new DummyParameterMetaData() {
+                     @Override
+                     public int getParameterCount() {
+                        return CaseSensitiveDatabasesTest.this.getParameterCount(fetchedSql[0]);
+                     }
+                     @Override
+                     public int getParameterType(int param) {
+                        return   param == 1 ? Types.INTEGER :
+                                 param == 2 ? Types.VARCHAR :
+                                 param == 3 ? Types.INTEGER
+                                            : Types.INTEGER;
+                     }
+                  };
+               }
+
+               @Override
+               public ResultSet getGeneratedKeys() {
+                  return new DummyResultSet() {
+                     @Override
+                     public boolean next() {
+                        return true;
+                     }
+
+                     @Override
+                     public Object getObject(int columnIndex) {
+                        return 123;
+                     }
+                  };
+               }
+            };
+         }
+      };
+      TestClass obj = OrmWriter.updateObject(con, new TestClass());
+      assertEquals("UPDATE Test_Class SET \"Delimited Field Name\"=?,Default_Case=?,myInt2=? WHERE \"Id\"=?", fetchedSql[0]);
+      assertEquals(defaultCaseValue, obj.myInt);
+      assertEquals(upperCaseValue, obj.delimitedFieldName);
+      assertEquals(123, obj.id);
    }
 
    @Test
@@ -707,7 +832,7 @@ public class CaseSensitiveDatabasesTest {
                   return 1;
                }
                @Override
-               public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+               public void setObject(int parameterIndex, Object x, int targetSqlType) {
                   fetchedId[0] = (String) x;
                }
 
@@ -944,27 +1069,95 @@ public class CaseSensitiveDatabasesTest {
    public void insertObjectH2() {
 
       SansOrm.initializeTxNone(TestUtils.makeH2DataSource());
-      SqlClosureElf.executeUpdate("CREATE TABLE \"Test Class\" ("
-         + "id INTEGER NOT NULL IDENTITY PRIMARY KEY, "
-         + "\"Delimited field name\" VARCHAR(128), "
-         + "Default_Case VARCHAR(128) "
-         + ")");
+      try {
+         SqlClosureElf.executeUpdate(
+               " CREATE TABLE \"Test Class\" ("
+            + "id INTEGER NOT NULL IDENTITY PRIMARY KEY, "
+            + "\"Delimited field name\" VARCHAR(128), "
+            + "Default_Case VARCHAR(128) "
+            + ")");
 
-      String delimitedFieldValue = "delimited field value";
-      String defaultCaseValue = "default case value";
-      InsertObjectH2 obj = SqlClosureElf.insertObject(new InsertObjectH2());
-      assertEquals(1, obj.Id);
-      obj = SqlClosureElf.getObjectById(InsertObjectH2.class, obj.Id);
-      assertNotNull(obj);
-      int count = SqlClosureElf.countObjectsFromClause(InsertObjectH2.class, "\"Delimited field name\" = 'delimited field value'");
-      assertEquals(1, count);
+         String delimitedFieldValue = "delimited field value";
+         String defaultCaseValue = "default case value";
+         InsertObjectH2 obj = SqlClosureElf.insertObject(new InsertObjectH2());
+         assertEquals(1, obj.Id);
+         obj = SqlClosureElf.getObjectById(InsertObjectH2.class, obj.Id);
+         assertNotNull(obj);
+         int count = SqlClosureElf.countObjectsFromClause(InsertObjectH2.class, "\"Delimited field name\" = 'delimited field value'");
+         assertEquals(1, count);
+      }
+      finally {
+         SqlClosureElf.executeUpdate("DELETE \"Test Class\"");
+      }
+   }
+
+   @Test
+   public void updateObjectH2GeneratedId() {
+
+      SansOrm.initializeTxNone(TestUtils.makeH2DataSource());
+      try {
+         SqlClosureElf.executeUpdate(
+            " CREATE TABLE \"Test Class\" ("
+            + "id INTEGER NOT NULL IDENTITY PRIMARY KEY, "
+            + "\"Delimited field name\" VARCHAR(128), "
+            + "Default_Case VARCHAR(128) "
+            + ")");
+
+         String delimitedFieldValue = "delimited field value";
+         String defaultCaseValue = "default case value";
+         InsertObjectH2 obj = new InsertObjectH2();
+         obj = SqlClosureElf.insertObject(obj);
+         obj.defaultCase = "changed";
+         obj = SqlClosureElf.updateObject(obj);
+         assertEquals("changed", obj.defaultCase);
+      }
+      finally {
+         SqlClosureElf.executeUpdate("DROP TABLE \"Test Class\"");
+      }
+   }
+
+   @Test
+   public void updateObjectH2GeneratedDelimitedId() throws SQLException {
+
+      @Table(name = "\"Test Class\"")
+      class TestClass {
+         @Id @GeneratedValue @Column(name = "\"Id\"")
+         int id;
+         @Column(name = "\"Delimited field name\"")
+         String delimitedFieldName = "delimited field value";
+         @Column(name = "Default_Case")
+         String defaultCase = "default case value";
+      }
+
+      try {
+         JdbcDataSource dataSource = TestUtils.makeH2DataSource();
+         SansOrm.initializeTxNone(dataSource);
+         SqlClosureElf.executeUpdate(
+            " CREATE TABLE \"Test Class\" ("
+            + "\"Id\" INTEGER NOT NULL IDENTITY PRIMARY KEY, "
+            + "\"Delimited field name\" VARCHAR(128), "
+            + "Default_Case VARCHAR(128) "
+            + ")");
+
+         String delimitedFieldValue = "delimited field value";
+         String defaultCaseValue = "default case value";
+         TestClass obj = new TestClass();
+         obj = SqlClosureElf.insertObject(obj);
+         obj.defaultCase = "changed";
+         obj = SqlClosureElf.updateObject(obj);
+         assertEquals("changed", obj.defaultCase);
+      }
+      finally {
+         SqlClosureElf.executeUpdate("DROP TABLE \"Test Class\"");
+      }
    }
 
    @Test
    public void getColumnNames() {
       Introspected introspected = new Introspected(InsertObjectH2.class);
       String[] columnNames = introspected.getColumnNames();
-      assertArrayEquals(new String[]{"Default_Case", "\"Delimited field name\"", "Id"}, columnNames);
+      // Preserve field order!!!
+      assertArrayEquals(new String[]{"Id", "\"Delimited field name\"", "Default_Case"}, columnNames);
    }
 
    @Test

--- a/src/test/java/com/zaxxer/sansorm/internal/IntrospectedTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/IntrospectedTest.java
@@ -20,7 +20,8 @@ public class IntrospectedTest
       assertThat(inspected).isNotNull();
       assertThat(inspected.hasGeneratedId()).isTrue();
       assertThat(inspected.getIdColumnNames()).isEqualTo(new String[]{"id"});
-      assertThat(inspected.getColumnNames()).isEqualTo(new String[]{"id", "string", "string_from_number", "timestamp"});
+      // 15.04.18: Was case insensitive lexicographic order ("id", "string", "string_from_number", "timestamp"). Now order as fields were supplied by inspection.
+      assertThat(inspected.getColumnNames()).isEqualTo(new String[]{"timestamp", "string_from_number", "id", "string"});
    }
 
    @Test
@@ -77,6 +78,7 @@ public class IntrospectedTest
       assertThat(inspected.getColumnNameForProperty("string")).isEqualTo("string");
       assertThat(inspected.hasGeneratedId()).isTrue();
       assertThat(inspected.getIdColumnNames()).isEqualTo(new String[]{"id"});
-      assertThat(inspected.getColumnNames()).isEqualTo(new String[]{"id", "string"});
+      // 15.04.18: Was case insensitive lexicographic order ("id", "string"). Now order as fields were supplied by inspection.
+      assertThat(inspected.getColumnNames()).isEqualTo(new String[]{"string", "id"});
    }
 }


### PR DESCRIPTION
@brettwooldridge As discussed all column infos are pre-calculated now.

Support for quoted identifiers made the code a little confusing, because we have now to distinguish case sensitive, case insensitive and delimited forms of field names depending on the work to do. I tried to clean this up. So all field/column related info is now encapsulated in FieldColumnInfo. As this class has grown up I extracted it to an external class.

OrmBase, OrmReader and OrmWriter internally work on FieldColumnInfo now instead of Strings. So every method can access all field/column related info to fulfil their duties. Due to the names of the methods they call on FieldColumnInfo it is clearer when reading the code which "case type" of field name they are working on and to realize errors in advance.

