### PR TITLE
Support for annotated getters

### DIFF
--- a/src/main/java/com/zaxxer/sansorm/internal/AttributeInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/AttributeInfo.java
@@ -43,7 +43,7 @@ abstract class AttributeInfo
    protected boolean isManyToOneAnnotated;
    protected boolean isOneToOneAnnotated;
 
-   public AttributeInfo(Field field, Class<?> clazz) {
+   public AttributeInfo(final Field field, final Class<?> clazz) {
       this.field = field;
       this.clazz = clazz;
       extractFieldName(field);
@@ -56,13 +56,13 @@ abstract class AttributeInfo
       }
    }
 
-   protected abstract void extractFieldName(Field field);
+   protected abstract void extractFieldName(final Field field);
 
    private Class<?> extractType() {
       return field.getType();
    }
 
-   private void adjustType(Class<?> type) {
+   private void adjustType(final Class<?> type) {
       if (type == null) {
          throw new IllegalArgumentException("AccessibleObject has to be of type Field or Method.");
       }
@@ -105,55 +105,55 @@ abstract class AttributeInfo
    }
 
    private void extractAnnotations() {
-      Id idAnnotation = extractIdAnnotation();
+      final Id idAnnotation = extractIdAnnotation();
       if (idAnnotation != null) {
          isIdField = true;
          GeneratedValue generatedAnnotation = extractGeneratedValueAnnotation();
          isGeneratedId = (generatedAnnotation != null);
       }
 
-      Enumerated enumAnnotation = extractEnumeratedAnnotation();
+      final Enumerated enumAnnotation = extractEnumeratedAnnotation();
       if (enumAnnotation != null) {
          isEnumerated = true;
          this.setEnumConstants(enumAnnotation.value());
       }
-      JoinColumn joinColumnAnnotation = extractJoinColumnAnnotation();
+      final JoinColumn joinColumnAnnotation = extractJoinColumnAnnotation();
       if (joinColumnAnnotation != null) {
          isJoinColumn = true;
       }
-      Transient transientAnnotation = extractTransientAnnotation();
+      final Transient transientAnnotation = extractTransientAnnotation();
       if (transientAnnotation != null) {
          isTransient = true;
          toBeConsidered = false;
       }
-      Column columnAnnotation = extractColumnAnnotation();
+      final Column columnAnnotation = extractColumnAnnotation();
       if (columnAnnotation != null) {
          isColumnAnnotated = true;
       }
-      JoinColumns joinColumns = extractJoinColumnsAnnotation();
+      final JoinColumns joinColumns = extractJoinColumnsAnnotation();
       if (joinColumns != null) {
          isJoinColumnsAnnotated = true;
          toBeConsidered = false;
       }
-      OneToMany oneToMany = extractOneToManyAnnotation();
+      final OneToMany oneToMany = extractOneToManyAnnotation();
       if (oneToMany != null) {
          isOneToManyAnnotated = true;
          toBeConsidered = false;
       }
       else {
-         ManyToMany manyToMany = extractManyToManyAnnotation();
+         final ManyToMany manyToMany = extractManyToManyAnnotation();
          if (manyToMany != null) {
             isManyToManyAnnotated = true;
             toBeConsidered = false;
          }
          else {
-            ManyToOne manyToOne = extractManyToOneAnnotation();
+            final ManyToOne manyToOne = extractManyToOneAnnotation();
             if (manyToOne != null) {
                isManyToOneAnnotated = true;
                toBeConsidered = false;
             }
             else {
-               OneToOne oneToOne = extractOneToOneAnnotation();
+               final OneToOne oneToOne = extractOneToOneAnnotation();
                if (oneToOne != null) {
                   isOneToOneAnnotated = true;
                }
@@ -183,9 +183,9 @@ abstract class AttributeInfo
    protected abstract Id extractIdAnnotation();
 
    private void processConvertAnnotation()  {
-      Convert convertAnnotation = extractConvertAnnotation();
+      final Convert convertAnnotation = extractConvertAnnotation();
       if (convertAnnotation != null) {
-         Class<?> converterClass = convertAnnotation.converter();
+         final Class<?> converterClass = convertAnnotation.converter();
          if (!AttributeConverter.class.isAssignableFrom(converterClass)) {
             throw new RuntimeException(
                "Convert annotation only supports converters implementing AttributeConverter");
@@ -205,8 +205,8 @@ abstract class AttributeInfo
     * Processes &#64;Column annotated fields.
     */
    private void processColumnAnnotation() {
-      Column columnAnnotation = extractColumnAnnotation();
-      String columnName = columnAnnotation.name();
+      final Column columnAnnotation = extractColumnAnnotation();
+      final String columnName = columnAnnotation.name();
       setColumnName(columnName);
 
       this.columnTableName = columnAnnotation.table();
@@ -217,7 +217,7 @@ abstract class AttributeInfo
    protected abstract Column extractColumnAnnotation();
 
    protected void processJoinColumnAnnotation() {
-      JoinColumn joinColumnAnnotation = extractJoinColumnAnnotation();
+      final JoinColumn joinColumnAnnotation = extractJoinColumnAnnotation();
       // Is the JoinColumn a self-join?
       if (type == clazz) {
          setColumnName(joinColumnAnnotation.name());
@@ -240,7 +240,7 @@ abstract class AttributeInfo
    }
 
    private void setColumnName(final String columnName) {
-      String colName = columnName.isEmpty()
+      final String colName = columnName.isEmpty()
          ? name // as per EJB specification, empty name in Column "defaults to the property or field name"
          : columnName;
       if (isNotDelimited(colName)) {
@@ -314,7 +314,7 @@ abstract class AttributeInfo
     *
     * @param tablePrefix Ignored when field has a non empty table element.
     */
-   public String getFullyQualifiedDelimitedFieldName(String ... tablePrefix) {
+   public String getFullyQualifiedDelimitedFieldName(final String ... tablePrefix) {
       return columnTableName.isEmpty() && tablePrefix.length > 0
          ? tablePrefix[0] + "." + fullyQualifiedDelimitedName
          : fullyQualifiedDelimitedName;
@@ -344,9 +344,9 @@ abstract class AttributeInfo
       return insertable;
    }
 
-   public abstract Object getValue(Object target) throws IllegalAccessException, InvocationTargetException;
+   public abstract Object getValue(final Object target) throws IllegalAccessException, InvocationTargetException;
 
-   public abstract void setValue(Object target, Object value) throws IllegalAccessException;
+   public abstract void setValue(final Object target, final Object value) throws IllegalAccessException;
 
    boolean isTransient() {
       return isTransient;

--- a/src/main/java/com/zaxxer/sansorm/internal/AttributeInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/AttributeInfo.java
@@ -150,7 +150,6 @@ abstract class AttributeInfo
             final ManyToOne manyToOne = extractManyToOneAnnotation();
             if (manyToOne != null) {
                isManyToOneAnnotated = true;
-               toBeConsidered = false;
             }
             else {
                final OneToOne oneToOne = extractOneToOneAnnotation();

--- a/src/main/java/com/zaxxer/sansorm/internal/AttributeInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/AttributeInfo.java
@@ -345,10 +345,29 @@ abstract class AttributeInfo
 
    public abstract Object getValue(final Object target) throws IllegalAccessException, InvocationTargetException;
 
+   protected Object extractIdentityFromParent(final Object obj) throws IllegalAccessException, InvocationTargetException {
+      if (obj != null) {
+         final Introspected introspected = new Introspected(obj.getClass());
+         final AttributeInfo generatedIdFcInfo = introspected.getGeneratedIdFcInfo();
+         return generatedIdFcInfo.getValue(obj);
+      }
+      else {
+         return null;
+      }
+   }
+
    public abstract void setValue(final Object target, final Object value) throws IllegalAccessException;
 
    boolean isTransient() {
       return isTransient;
+   }
+
+   protected Object idValueToParent(final Object target, final Object value) throws InstantiationException, IllegalAccessException {
+      final Object obj = target.getClass().newInstance();
+      final Introspected introspected = new Introspected(obj.getClass());
+      final AttributeInfo generatedIdFcInfo = introspected.getGeneratedIdFcInfo();
+      generatedIdFcInfo.setValue(obj, value);
+      return obj;
    }
 
    boolean isToBeConsidered() {

--- a/src/main/java/com/zaxxer/sansorm/internal/AttributeInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/AttributeInfo.java
@@ -345,7 +345,7 @@ abstract class AttributeInfo
 
    public abstract Object getValue(final Object target) throws IllegalAccessException, InvocationTargetException;
 
-   protected Object extractIdentityFromParent(final Object obj) throws IllegalAccessException, InvocationTargetException {
+   protected Object idValueFromParentEntity(final Object obj) throws IllegalAccessException, InvocationTargetException {
       if (obj != null) {
          final Introspected introspected = new Introspected(obj.getClass());
          final AttributeInfo generatedIdFcInfo = introspected.getGeneratedIdFcInfo();
@@ -362,7 +362,7 @@ abstract class AttributeInfo
       return isTransient;
    }
 
-   protected Object idValueToParent(final Object target, final Object value) throws InstantiationException, IllegalAccessException {
+   protected Object idValueToParentEntity(final Object target, final Object value) throws InstantiationException, IllegalAccessException {
       final Object obj = target.getClass().newInstance();
       final Introspected introspected = new Introspected(obj.getClass());
       final AttributeInfo generatedIdFcInfo = introspected.getGeneratedIdFcInfo();

--- a/src/main/java/com/zaxxer/sansorm/internal/FieldInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/FieldInfo.java
@@ -63,7 +63,6 @@ public class FieldInfo extends AttributeInfo {
       return field.getDeclaredAnnotation(GeneratedValue.class);
    }
 
-   // TODO duplicate code as in PropertyInfo
    public Object getValue(final Object target) throws IllegalAccessException, InvocationTargetException {
       if (!isSelfJoinField()) {
          return field.get(target);
@@ -72,7 +71,6 @@ public class FieldInfo extends AttributeInfo {
       return extractIdentityFromParent(obj);
    }
 
-   // TODO duplicate code as in PropertyInfo
    public void setValue(final Object target, final Object value) throws IllegalAccessException {
       try {
          if (!isSelfJoinField()) {

--- a/src/main/java/com/zaxxer/sansorm/internal/FieldInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/FieldInfo.java
@@ -9,12 +9,12 @@ import java.lang.reflect.*;
  */
 public class FieldInfo extends AttributeInfo {
 
-   public FieldInfo(Field field, Class clazz) {
+   public FieldInfo(final Field field, final Class clazz) {
       super(field, clazz);
       field.setAccessible(true);
    }
 
-   protected void extractFieldName(Field accessibleObject) {
+   protected void extractFieldName(final Field accessibleObject) {
       this.name = accessibleObject.getName();
    }
 
@@ -63,11 +63,11 @@ public class FieldInfo extends AttributeInfo {
       return field.getDeclaredAnnotation(GeneratedValue.class);
    }
 
-   public Object getValue(Object target) throws IllegalAccessException {
+   public Object getValue(final Object target) throws IllegalAccessException {
       return field.get(target);
    }
 
-   public void setValue(Object target, Object value) throws IllegalAccessException {
+   public void setValue(final Object target, final Object value) throws IllegalAccessException {
       field.set(target, value);
    }
 

--- a/src/main/java/com/zaxxer/sansorm/internal/FieldInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/FieldInfo.java
@@ -63,31 +63,23 @@ public class FieldInfo extends AttributeInfo {
       return field.getDeclaredAnnotation(GeneratedValue.class);
    }
 
+   // TODO duplicate code as in PropertyInfo
    public Object getValue(final Object target) throws IllegalAccessException, InvocationTargetException {
       if (!isSelfJoinField()) {
          return field.get(target);
       }
       Object obj = field.get(target);
-      if (obj != null) {
-         final Introspected introspected = new Introspected(obj.getClass());
-         final AttributeInfo generatedIdFcInfo = introspected.getGeneratedIdFcInfo();
-         return generatedIdFcInfo.getValue(obj);
-      }
-      else {
-         return null;
-      }
+      return extractIdentityFromParent(obj);
    }
 
+   // TODO duplicate code as in PropertyInfo
    public void setValue(final Object target, final Object value) throws IllegalAccessException {
       try {
          if (!isSelfJoinField()) {
             field.set(target, value);
          }
          else {
-            final Object obj = target.getClass().newInstance();
-            final Introspected introspected = new Introspected(obj.getClass());
-            final AttributeInfo generatedIdFcInfo = introspected.getGeneratedIdFcInfo();
-            generatedIdFcInfo.setValue(obj, value);
+            final Object obj = idValueToParent(target, value);
             field.set(target, obj);
          }
       }

--- a/src/main/java/com/zaxxer/sansorm/internal/FieldInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/FieldInfo.java
@@ -1,0 +1,63 @@
+package com.zaxxer.sansorm.internal;
+
+import javax.persistence.*;
+import java.lang.reflect.*;
+
+/**
+ * @author Holger Thurow (thurow.h@gmail.com)
+ * @since 23.04.18
+ */
+public class FieldInfo extends AttributeInfo {
+
+   public FieldInfo(Field field, Class clazz) {
+      super(field, clazz);
+      field.setAccessible(true);
+   }
+
+   protected void extractFieldName(Field accessibleObject) {
+      this.name = accessibleObject.getName();
+   }
+
+   @Override
+   protected Transient extractTransientAnnotation() {
+      return field.getAnnotation(Transient.class);
+   }
+
+   @Override
+   protected JoinColumn extractJoinColumnAnnotation() {
+      return field.getAnnotation(JoinColumn.class);
+   }
+
+   @Override
+   protected Enumerated extractEnumeratedAnnotation() {
+      return field.getAnnotation(Enumerated.class);
+   }
+
+   @Override
+   protected GeneratedValue extractGeneratedValueAnnotation() {
+      return field.getAnnotation(GeneratedValue.class);
+   }
+
+   public Object getValue(Object target) throws IllegalAccessException {
+      return field.get(target);
+   }
+
+   public void setValue(Object target, Object value) throws IllegalAccessException {
+      field.set(target, value);
+   }
+
+   @Override
+   protected Column extractColumnAnnotation() {
+      return field.getAnnotation(Column.class);
+   }
+
+   @Override
+   protected Id extractIdAnnotation() {
+      return field.getAnnotation(Id.class);
+   }
+
+   @Override
+   protected Convert extractConvertAnnotation() {
+      return field.getAnnotation(Convert.class);
+   }
+}

--- a/src/main/java/com/zaxxer/sansorm/internal/FieldInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/FieldInfo.java
@@ -68,7 +68,7 @@ public class FieldInfo extends AttributeInfo {
          return field.get(target);
       }
       Object obj = field.get(target);
-      return extractIdentityFromParent(obj);
+      return idValueFromParentEntity(obj);
    }
 
    public void setValue(final Object target, final Object value) throws IllegalAccessException {
@@ -77,7 +77,7 @@ public class FieldInfo extends AttributeInfo {
             field.set(target, value);
          }
          else {
-            final Object obj = idValueToParent(target, value);
+            final Object obj = idValueToParentEntity(target, value);
             field.set(target, obj);
          }
       }

--- a/src/main/java/com/zaxxer/sansorm/internal/FieldInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/FieldInfo.java
@@ -19,23 +19,48 @@ public class FieldInfo extends AttributeInfo {
    }
 
    @Override
+   protected OneToOne extractOneToOneAnnotation() {
+      return field.getDeclaredAnnotation(OneToOne.class);
+   }
+
+   @Override
+   protected ManyToOne extractManyToOneAnnotation() {
+      return field.getDeclaredAnnotation(ManyToOne.class);
+   }
+
+   @Override
+   protected ManyToMany extractManyToManyAnnotation() {
+      return field.getDeclaredAnnotation(ManyToMany.class);
+   }
+
+   @Override
+   protected OneToMany extractOneToManyAnnotation() {
+      return field.getDeclaredAnnotation(OneToMany.class);
+   }
+
+   @Override
+   protected JoinColumns extractJoinColumnsAnnotation() {
+      return field.getDeclaredAnnotation(JoinColumns.class);
+   }
+
+   @Override
    protected Transient extractTransientAnnotation() {
-      return field.getAnnotation(Transient.class);
+      return field.getDeclaredAnnotation(Transient.class);
    }
 
    @Override
    protected JoinColumn extractJoinColumnAnnotation() {
-      return field.getAnnotation(JoinColumn.class);
+      return field.getDeclaredAnnotation(JoinColumn.class);
    }
 
    @Override
    protected Enumerated extractEnumeratedAnnotation() {
-      return field.getAnnotation(Enumerated.class);
+      return field.getDeclaredAnnotation(Enumerated.class);
    }
 
    @Override
    protected GeneratedValue extractGeneratedValueAnnotation() {
-      return field.getAnnotation(GeneratedValue.class);
+      return field.getDeclaredAnnotation(GeneratedValue.class);
    }
 
    public Object getValue(Object target) throws IllegalAccessException {
@@ -48,16 +73,16 @@ public class FieldInfo extends AttributeInfo {
 
    @Override
    protected Column extractColumnAnnotation() {
-      return field.getAnnotation(Column.class);
+      return field.getDeclaredAnnotation(Column.class);
    }
 
    @Override
    protected Id extractIdAnnotation() {
-      return field.getAnnotation(Id.class);
+      return field.getDeclaredAnnotation(Id.class);
    }
 
    @Override
    protected Convert extractConvertAnnotation() {
-      return field.getAnnotation(Convert.class);
+      return field.getDeclaredAnnotation(Convert.class);
    }
 }

--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -150,7 +150,7 @@ public final class Introspected
     * superclasses.
     */
    private Collection<Field> getDeclaredFields() {
-      fieldsAccessType = new HashMap<Field, AccessType>();
+      fieldsAccessType = new HashMap<>();
       final LinkedList<Field> declaredFields = new LinkedList<>(Arrays.asList(clazz.getDeclaredFields()));
       analyzeAccessType(declaredFields, clazz);
       for (Class<?> c = clazz.getSuperclass(); c != null; c = c.getSuperclass()) {

--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -176,13 +176,13 @@ public final class Introspected
       extractClassTableName();
 
       try {
-         for (Field field : getDeclaredFields()) {
+         for (final Field field : getDeclaredFields()) {
             final int modifiers = field.getModifiers();
             if (Modifier.isStatic(modifiers) || Modifier.isFinal(modifiers) || Modifier.isTransient(modifiers)) {
                continue;
             }
 
-            Class<?> fieldClass = field.getDeclaringClass();
+            final Class<?> fieldClass = field.getDeclaringClass();
             final AttributeInfo fcInfo =
                   fieldsAccessType.get(field) == AccessType.FIELD
                      ? new FieldInfo(field, fieldClass)
@@ -253,7 +253,7 @@ public final class Introspected
          // "A mapped superclass has no separate table defined for it".
          if (c.getAnnotation(MappedSuperclass.class) != null) {
             if (c.getAnnotation(Table.class) == null) {
-               List<Field> df = Arrays.asList(c.getDeclaredFields());
+               final List<Field> df = Arrays.asList(c.getDeclaredFields());
                declaredFields.addAll(df);
                analyzeAccessType(df, c);
             }
@@ -271,7 +271,7 @@ public final class Introspected
     * <p>
     * "An access type for an individual entity class, mapped superclass, or embeddable class can be specified for that class independent of the default for the entity hierarchy" ... When Access(FIELD) is applied to an entity class it is possible to selectively designate individual attributes within the class for property access ... When Access(PROPERTY) is applied to an entity class it is possible to selectively designate individual attributes within the class for instance variable access. It is not permitted to specify a field as Access(PROPERTY) or a property as Access(FIELD)." (JSR 317: JavaTM Persistence API, Version 2.0, 2.3.2 Explicit Access Type)
     */
-   private void analyzeAccessType(List<Field> declaredFields, Class<?> cl) {
+   private void analyzeAccessType(final List<Field> declaredFields, final Class<?> cl) {
       if (isExplicitPropertyAccess(cl)) {
          analyzeExplicitPropertyAccess(declaredFields, cl);
       }
@@ -283,16 +283,16 @@ public final class Introspected
       }
    }
 
-   private void analyzeDefaultAccess(List<Field> declaredFields, Class<?> cl) {
+   private void analyzeDefaultAccess(final List<Field> declaredFields, final Class<?> cl) {
       declaredFields.forEach(field -> {
-         boolean isDefaultFieldAccess = declaredFields.stream().anyMatch(this::isJpaAnnotated);
+         final boolean isDefaultFieldAccess = declaredFields.stream().anyMatch(this::isJpaAnnotated);
          if (isDefaultFieldAccess) {
             fieldsAccessType.put(field, AccessType.FIELD);
          }
          else {
-            Method[] declaredMethods = cl.getDeclaredMethods();
+            final Method[] declaredMethods = cl.getDeclaredMethods();
             if (declaredMethods.length != 0) {
-               boolean isDefaultPropertyAccess = Arrays.stream(declaredMethods).anyMatch(this::isJpaAnnotated);
+               final boolean isDefaultPropertyAccess = Arrays.stream(declaredMethods).anyMatch(this::isJpaAnnotated);
                fieldsAccessType.put(
                   field,
                   isDefaultPropertyAccess ? AccessType.PROPERTY : AccessType.FIELD);
@@ -305,13 +305,13 @@ public final class Introspected
       });
    }
 
-   private void analyzeExlicitFieldAccess(List<Field> declaredFields, Class<?> cl) {
+   private void analyzeExlicitFieldAccess(final List<Field> declaredFields, final Class<?> cl) {
       declaredFields.forEach(field -> {
          try {
-            PropertyDescriptor descriptor = new PropertyDescriptor(field.getName(), cl);
-            Method readMethod = descriptor.getReadMethod();
-            Access accessTypeOnMethod = readMethod.getAnnotation(Access.class);
-            Access accessTypeOnField = field.getDeclaredAnnotation(Access.class);
+            final PropertyDescriptor descriptor = new PropertyDescriptor(field.getName(), cl);
+            final Method readMethod = descriptor.getReadMethod();
+            final Access accessTypeOnMethod = readMethod.getAnnotation(Access.class);
+            final Access accessTypeOnField = field.getDeclaredAnnotation(Access.class);
             if (accessTypeOnMethod == null) {
                if (accessTypeOnField == null || accessTypeOnField.value() == AccessType.FIELD) {
                   fieldsAccessType.put(field, AccessType.FIELD);
@@ -334,13 +334,13 @@ public final class Introspected
       });
    }
 
-   private void analyzeExplicitPropertyAccess(List<Field> declaredFields, Class<?> cl) {
+   private void analyzeExplicitPropertyAccess(final List<Field> declaredFields, final Class<?> cl) {
       declaredFields.forEach(field -> {
          try {
-            PropertyDescriptor descriptor = new PropertyDescriptor(field.getName(), cl);
-            Method readMethod = descriptor.getReadMethod();
-            Access accessTypeOnMethod = readMethod.getAnnotation(Access.class);
-            Access accessTypeOnField = field.getDeclaredAnnotation(Access.class);
+            final PropertyDescriptor descriptor = new PropertyDescriptor(field.getName(), cl);
+            final Method readMethod = descriptor.getReadMethod();
+            final Access accessTypeOnMethod = readMethod.getAnnotation(Access.class);
+            final Access accessTypeOnField = field.getDeclaredAnnotation(Access.class);
             if (accessTypeOnField == null) {
                if (accessTypeOnMethod == null || accessTypeOnMethod.value() == AccessType.PROPERTY) {
                   fieldsAccessType.put(field, AccessType.PROPERTY);
@@ -377,21 +377,20 @@ public final class Introspected
       }
    }
 
-   boolean isExplicitFieldAccess(Class<?> fieldClass) {
-      Access accessType = fieldClass.getAnnotation(Access.class);
+   boolean isExplicitFieldAccess(final Class<?> fieldClass) {
+      final Access accessType = fieldClass.getAnnotation(Access.class);
       return accessType != null && accessType.value() == AccessType.FIELD;
    }
 
-   boolean isExplicitPropertyAccess(Class<?> c) {
-      Access accessType = c.getAnnotation(Access.class);
+   boolean isExplicitPropertyAccess(final Class<?> c) {
+      final Access accessType = c.getAnnotation(Access.class);
       return accessType != null && accessType.value() == AccessType.PROPERTY;
    }
 
-   boolean isJpaAnnotated(AccessibleObject fieldOrMethod) {
-      Annotation[] annotations = fieldOrMethod.getDeclaredAnnotations();
+   boolean isJpaAnnotated(final AccessibleObject fieldOrMethod) {
+      final Annotation[] annotations = fieldOrMethod.getDeclaredAnnotations();
       //noinspection ForLoopReplaceableByForEach
       for (int i = 0; i < annotations.length; i++) {
-
          if (jpaAnnotations.contains(annotations[i].annotationType())) {
             return true;
          }
@@ -437,7 +436,7 @@ public final class Introspected
     * @param value the value to set into the field of the target instance, possibly after applying a
     *              {@link AttributeConverter}
     */
-   void set(Object target, AttributeInfo fcInfo, Object value)
+   void set(final Object target, final AttributeInfo fcInfo, final Object value)
    {
       if (fcInfo == null) {
          throw new RuntimeException("FieldColumnInfo must not be null. Type is " + target.getClass().getCanonicalName());
@@ -699,17 +698,17 @@ public final class Introspected
    {
       idFieldColumnInfos = new AttributeInfo[idFcInfos.size()];
       idColumnNames = new String[idFcInfos.size()];
-      String[] columnNames = new String[columnToField.size()];
+      final String[] columnNames = new String[columnToField.size()];
       columnTableNames = new String[columnNames.length];
       caseSensitiveColumnNames = new String[columnNames.length];
       delimitedColumnNames = new String[columnNames.length];
-      String[] columnsSansIds = new String[columnNames.length - idColumnNames.length];
+      final String[] columnsSansIds = new String[columnNames.length - idColumnNames.length];
       delimitedColumnsSansIds = new String[columnsSansIds.length];
       selectableFcInfosArray = new AttributeInfo[allFcInfos.size()];
 
       int fieldCount = 0, idCount = 0, sansIdCount = 0;
 
-      for (AttributeInfo fcInfo : allFcInfos) {
+      for (final AttributeInfo fcInfo : allFcInfos) {
          if (fcInfo.isToBeConsidered()) {
             columnNames[fieldCount] = fcInfo.getColumnName();
             caseSensitiveColumnNames[fieldCount] = fcInfo.getCaseSensitiveColumnName();
@@ -740,7 +739,7 @@ public final class Introspected
          final StringBuilder sb = new StringBuilder();
          final char[] cbuf = new char[1024];
          while (true) {
-            int rc = reader.read(cbuf);
+            final int rc = reader.read(cbuf);
             if (rc == -1) {
                break;
             }

--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -30,7 +30,6 @@ import java.math.BigInteger;
 import java.sql.Clob;
 import java.sql.SQLException;
 import java.util.*;
-import java.util.stream.Stream;
 
 /**
  * An introspected class.
@@ -64,6 +63,7 @@ public final class Introspected
    private AttributeInfo[] insertableFcInfosArray;
    private AttributeInfo[] updatableFcInfosArray;
    private AttributeInfo[] selectableFcInfosArray;
+
    private static final HashSet<Class<?>> jpaAnnotations = new HashSet<>();
 
    static {
@@ -207,10 +207,10 @@ public final class Introspected
                      }
                   }
                }
-               else if (fcInfo.isSelfJoinField()) {
-                  selfJoinFCInfo = fcInfo;
-               }
                else {
+                  if (fcInfo.isSelfJoinField()) {
+                     selfJoinFCInfo = fcInfo;
+                  }
                   if (fcInfo.isInsertable() == null || fcInfo.isInsertable()) {
                      insertableFcInfos.add(fcInfo);
                   }
@@ -772,6 +772,9 @@ public final class Introspected
       return selectableFcInfosArray;
    }
 
+   /**
+    * @return Any id field regardless of whether it is auto-generated or not.
+    */
    public List<AttributeInfo> getIdFcInfos() {
       return idFcInfos;
    }

--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -23,6 +23,7 @@ import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.io.IOException;
 import java.io.Reader;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -63,6 +64,99 @@ public final class Introspected
    private AttributeInfo[] insertableFcInfosArray;
    private AttributeInfo[] updatableFcInfosArray;
    private AttributeInfo[] selectableFcInfosArray;
+   private final HashSet<Class<?>> jpaAnnotations = new HashSet<>();
+
+   {
+//         jpaAnnotations.add(Access.class);
+      jpaAnnotations.add(AssociationOverride.class);
+      jpaAnnotations.add(AssociationOverrides.class);
+      jpaAnnotations.add(AttributeOverride.class);
+      jpaAnnotations.add(AttributeOverrides.class);
+      jpaAnnotations.add(Basic.class);
+//         jpaAnnotations.add(Cacheable.class);
+      jpaAnnotations.add(CollectionTable.class);
+      jpaAnnotations.add(Column.class);
+      jpaAnnotations.add(ColumnResult.class);
+      jpaAnnotations.add(ConstructorResult.class);
+      jpaAnnotations.add(Convert.class);
+      jpaAnnotations.add(Converter.class);
+      jpaAnnotations.add(Converts.class);
+      jpaAnnotations.add(DiscriminatorColumn.class);
+      jpaAnnotations.add(DiscriminatorValue.class);
+      jpaAnnotations.add(ElementCollection.class);
+      jpaAnnotations.add(Embeddable.class);
+      jpaAnnotations.add(Embedded.class);
+      jpaAnnotations.add(EmbeddedId.class);
+      jpaAnnotations.add(Entity.class);
+      jpaAnnotations.add(EntityListeners.class);
+      jpaAnnotations.add(EntityResult.class);
+      jpaAnnotations.add(Enumerated.class);
+      jpaAnnotations.add(ExcludeDefaultListeners.class);
+      jpaAnnotations.add(ExcludeSuperclassListeners.class);
+      jpaAnnotations.add(FieldResult.class);
+      jpaAnnotations.add(ForeignKey.class);
+      jpaAnnotations.add(GeneratedValue.class);
+      jpaAnnotations.add(Id.class);
+      jpaAnnotations.add(IdClass.class);
+      jpaAnnotations.add(Index.class);
+      jpaAnnotations.add(Inheritance.class);
+      jpaAnnotations.add(JoinColumn.class);
+      jpaAnnotations.add(JoinColumns.class);
+      jpaAnnotations.add(JoinTable.class);
+      jpaAnnotations.add(Lob.class);
+      jpaAnnotations.add(ManyToMany.class);
+      jpaAnnotations.add(ManyToOne.class);
+      jpaAnnotations.add(MapKey.class);
+      jpaAnnotations.add(MapKeyClass.class);
+      jpaAnnotations.add(MapKeyColumn.class);
+      jpaAnnotations.add(MapKeyEnumerated.class);
+      jpaAnnotations.add(MapKeyJoinColumn.class);
+      jpaAnnotations.add(MapKeyJoinColumns.class);
+      jpaAnnotations.add(MapKeyTemporal.class);
+      jpaAnnotations.add(MappedSuperclass.class);
+      jpaAnnotations.add(MapsId.class);
+      jpaAnnotations.add(NamedAttributeNode.class);
+      jpaAnnotations.add(NamedEntityGraph.class);
+      jpaAnnotations.add(NamedEntityGraphs.class);
+      jpaAnnotations.add(NamedNativeQueries.class);
+      jpaAnnotations.add(NamedNativeQuery.class);
+      jpaAnnotations.add(NamedQueries.class);
+      jpaAnnotations.add(NamedQuery.class);
+      jpaAnnotations.add(NamedStoredProcedureQueries.class);
+      jpaAnnotations.add(NamedStoredProcedureQuery.class);
+      jpaAnnotations.add(NamedSubgraph.class);
+      jpaAnnotations.add(OneToMany.class);
+      jpaAnnotations.add(OneToOne.class);
+      jpaAnnotations.add(OrderBy.class);
+      jpaAnnotations.add(OrderColumn.class);
+      jpaAnnotations.add(PersistenceContext.class);
+      jpaAnnotations.add(PersistenceContexts.class);
+      jpaAnnotations.add(PersistenceProperty.class);
+      jpaAnnotations.add(PersistenceUnit.class);
+      jpaAnnotations.add(PersistenceUnits.class);
+      jpaAnnotations.add(PostLoad.class);
+      jpaAnnotations.add(PostPersist.class);
+      jpaAnnotations.add(PostRemove.class);
+      jpaAnnotations.add(PostUpdate.class);
+      jpaAnnotations.add(PrePersist.class);
+      jpaAnnotations.add(PreRemove.class);
+      jpaAnnotations.add(PreUpdate.class);
+      jpaAnnotations.add(PrimaryKeyJoinColumn.class);
+      jpaAnnotations.add(PrimaryKeyJoinColumns.class);
+      jpaAnnotations.add(QueryHint.class);
+//         jpaAnnotations.add(SecondaryTable.class);
+//         jpaAnnotations.add(SecondaryTables.class);
+//         jpaAnnotations.add(SequenceGenerator.class);
+      jpaAnnotations.add(SqlResultSetMapping.class);
+      jpaAnnotations.add(SqlResultSetMappings.class);
+      jpaAnnotations.add(StoredProcedureParameter.class);
+//         jpaAnnotations.add(Table.class);
+//         jpaAnnotations.add(TableGenerator.class);
+      jpaAnnotations.add(Temporal.class);
+      jpaAnnotations.add(Transient.class);
+//         jpaAnnotations.add(UniqueConstraint.class);
+      jpaAnnotations.add(Version.class);
+   }
 
    /**
     * Constructor. Introspect the specified class and cache various annotation data about it.
@@ -294,97 +388,15 @@ public final class Introspected
    }
 
    boolean isJpaAnnotated(AccessibleObject fieldOrMethod) {
-      return Stream.of(
-//         Access.class,
-         AssociationOverride.class,
-         AssociationOverrides.class,
-         AttributeOverride.class,
-         AttributeOverrides.class,
-         Basic.class,
-//         Cacheable.class,
-         CollectionTable.class,
-         Column.class,
-         ColumnResult.class,
-         ConstructorResult.class,
-         Convert.class,
-         Converter.class,
-         Converts.class,
-         DiscriminatorColumn.class,
-         DiscriminatorValue.class,
-         ElementCollection.class,
-         Embeddable.class,
-         Embedded.class,
-         EmbeddedId.class,
-         Entity.class,
-         EntityListeners.class,
-         EntityResult.class,
-         Enumerated.class,
-         ExcludeDefaultListeners.class,
-         ExcludeSuperclassListeners.class,
-         FieldResult.class,
-         ForeignKey.class,
-         GeneratedValue.class,
-         Id.class,
-         IdClass.class,
-         Index.class,
-         Inheritance.class,
-         JoinColumn.class,
-         JoinColumns.class,
-         JoinTable.class,
-         Lob.class,
-         ManyToMany.class,
-         ManyToOne.class,
-         MapKey.class,
-         MapKeyClass.class,
-         MapKeyColumn.class,
-         MapKeyEnumerated.class,
-         MapKeyJoinColumn.class,
-         MapKeyJoinColumns.class,
-         MapKeyTemporal.class,
-         MappedSuperclass.class,
-         MapsId.class,
-         NamedAttributeNode.class,
-         NamedEntityGraph.class,
-         NamedEntityGraphs.class,
-         NamedNativeQueries.class,
-         NamedNativeQuery.class,
-         NamedQueries.class,
-         NamedQuery.class,
-         NamedStoredProcedureQueries.class,
-         NamedStoredProcedureQuery.class,
-         NamedSubgraph.class,
-         OneToMany.class,
-         OneToOne.class,
-         OrderBy.class,
-         OrderColumn.class,
-         PersistenceContext.class,
-         PersistenceContexts.class,
-         PersistenceProperty.class,
-         PersistenceUnit.class,
-         PersistenceUnits.class,
-         PostLoad.class,
-         PostPersist.class,
-         PostRemove.class,
-         PostUpdate.class,
-         PrePersist.class,
-         PreRemove.class,
-         PreUpdate.class,
-         PrimaryKeyJoinColumn.class,
-         PrimaryKeyJoinColumns.class,
-         QueryHint.class,
-//         SecondaryTable.class,
-//         SecondaryTables.class,
-//         SequenceGenerator.class,
-         SqlResultSetMapping.class,
-         SqlResultSetMappings.class,
-         StoredProcedureParameter.class,
-//         Table.class,
-//         TableGenerator.class,
-         Temporal.class,
-         Transient.class,
-//         UniqueConstraint.class,
-         Version.class
-      ).anyMatch(cl -> fieldOrMethod.getDeclaredAnnotation(cl) != null);
+      Annotation[] annotations = fieldOrMethod.getDeclaredAnnotations();
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0; i < annotations.length; i++) {
+
+         if (jpaAnnotations.contains(annotations[i].annotationType())) {
+            return true;
+         }
+      }
+      return false;
    }
 
    /**

--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -66,7 +66,7 @@ public final class Introspected
    private AttributeInfo[] selectableFcInfosArray;
    private static final HashSet<Class<?>> jpaAnnotations = new HashSet<>();
 
-   {
+   static {
 //         jpaAnnotations.add(Access.class);
       jpaAnnotations.add(AssociationOverride.class);
       jpaAnnotations.add(AssociationOverrides.class);

--- a/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/Introspected.java
@@ -64,7 +64,7 @@ public final class Introspected
    private AttributeInfo[] insertableFcInfosArray;
    private AttributeInfo[] updatableFcInfosArray;
    private AttributeInfo[] selectableFcInfosArray;
-   private final HashSet<Class<?>> jpaAnnotations = new HashSet<>();
+   private static final HashSet<Class<?>> jpaAnnotations = new HashSet<>();
 
    {
 //         jpaAnnotations.add(Access.class);

--- a/src/main/java/com/zaxxer/sansorm/internal/OrmBase.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/OrmBase.java
@@ -70,8 +70,8 @@ class OrmBase
         final StringBuilder sb = new StringBuilder();
 
         final Introspected introspected = Introspector.getIntrospected(clazz);
-        final FieldColumnInfo[] selectableFields = introspected.getSelectableFcInfos();
-        for (FieldColumnInfo selectableField : selectableFields) {
+        final AttributeInfo[] selectableFields = introspected.getSelectableFcInfos();
+        for (AttributeInfo selectableField : selectableFields) {
            sb.append(selectableField.getFullyQualifiedDelimitedFieldName(tablePrefix)).append(',');
         }
 
@@ -89,8 +89,8 @@ class OrmBase
       final StringBuilder sb = new StringBuilder();
 
       final Introspected introspected = Introspector.getIntrospected(clazz);
-      final FieldColumnInfo[] selectableFields = introspected.getSelectableFcInfos();
-      for (FieldColumnInfo selectableField : selectableFields) {
+      final AttributeInfo[] selectableFields = introspected.getSelectableFcInfos();
+      for (AttributeInfo selectableField : selectableFields) {
          if (!excludes.contains(selectableField.getCaseSensitiveColumnName())) {
             sb.append(selectableField.getFullyQualifiedDelimitedFieldName()).append(',');
          }

--- a/src/main/java/com/zaxxer/sansorm/internal/OrmBase.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/OrmBase.java
@@ -52,10 +52,10 @@ class OrmBase
          throw new RuntimeException("Too few parameters supplied for query");
       }
 
-      for (int column = paramCount; column > 0; column--) {
-         final int parameterType = parameterMetaData.getParameterType(column);
-         final Object object = mapSqlType(args[column - 1], parameterType);
-         stmt.setObject(column, object, parameterType);
+      for (int i = paramCount; i > 0; i--) {
+         final int parameterType = parameterMetaData.getParameterType(i);
+         final Object object = mapSqlType(args[i - 1], parameterType);
+         stmt.setObject(i, object, parameterType);
       }
    }
 

--- a/src/main/java/com/zaxxer/sansorm/internal/OrmBase.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/OrmBase.java
@@ -52,10 +52,10 @@ class OrmBase
          throw new RuntimeException("Too few parameters supplied for query");
       }
 
-      for (int i = paramCount; i > 0; i--) {
-         final int parameterType = parameterMetaData.getParameterType(i);
-         final Object object = mapSqlType(args[i - 1], parameterType);
-         stmt.setObject(i, object, parameterType);
+      for (int colIdx = paramCount; colIdx > 0; colIdx--) {
+         final int parameterType = parameterMetaData.getParameterType(colIdx);
+         final Object object = mapSqlType(args[colIdx - 1], parameterType);
+         stmt.setObject(colIdx, object, parameterType);
       }
    }
 

--- a/src/main/java/com/zaxxer/sansorm/internal/OrmReader.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/OrmReader.java
@@ -181,7 +181,7 @@ public class OrmReader extends OrmBase
          if (columnValue == null) {
             continue;
          }
-         AttributeInfo fcInfo = introspected.getFieldColumnInfo(columnName);
+         final AttributeInfo fcInfo = introspected.getFieldColumnInfo(columnName);
          introspected.set(target, fcInfo, columnValue);
       }
       return target;

--- a/src/main/java/com/zaxxer/sansorm/internal/OrmReader.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/OrmReader.java
@@ -87,7 +87,7 @@ public class OrmReader extends OrmBase
                }
 
                final String columnName = columnNames[column - 1];
-               final FieldColumnInfo fcInfo = introspected.getFieldColumnInfo(columnName);
+               final AttributeInfo fcInfo = introspected.getFieldColumnInfo(columnName);
                if (fcInfo.isSelfJoinField()) {
                   deferredSelfJoinFkMap.put(target, columnValue);
                }
@@ -109,7 +109,7 @@ public class OrmReader extends OrmBase
       try {
          if (hasJoinColumns) {
             // set the self join object instances based on the foreign key ids...
-            final FieldColumnInfo idColumn = introspected.getSelfJoinColumnInfo();
+            final AttributeInfo idColumn = introspected.getSelfJoinColumnInfo();
             for (Entry<T, Object> entry : deferredSelfJoinFkMap.entrySet()) {
                final T value = idToTargetMap.get(entry.getValue());
                if (value != null) {

--- a/src/main/java/com/zaxxer/sansorm/internal/OrmReader.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/OrmReader.java
@@ -75,8 +75,8 @@ public class OrmReader extends OrmBase
       final ResultSetMetaData metaData = resultSet.getMetaData();
       final int columnCount = metaData.getColumnCount();
       final String[] columnNames = new String[columnCount];
-      for (int i = columnCount; i > 0; i--) {
-         columnNames[i - 1] = metaData.getColumnName(i).toLowerCase();
+      for (int colIdx = columnCount; colIdx > 0; colIdx--) {
+         columnNames[colIdx - 1] = metaData.getColumnName(colIdx).toLowerCase();
       }
 
       try (final ResultSet closeRS = resultSet) {

--- a/src/main/java/com/zaxxer/sansorm/internal/OrmReader.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/OrmReader.java
@@ -16,6 +16,9 @@
 
 package com.zaxxer.sansorm.internal;
 
+import com.zaxxer.sansorm.SansOrm;
+
+import java.lang.reflect.InvocationTargetException;
 import java.sql.*;
 import java.util.*;
 import java.util.Map.Entry;
@@ -72,8 +75,8 @@ public class OrmReader extends OrmBase
       final ResultSetMetaData metaData = resultSet.getMetaData();
       final int columnCount = metaData.getColumnCount();
       final String[] columnNames = new String[columnCount];
-      for (int column = columnCount; column > 0; column--) {
-         columnNames[column - 1] = metaData.getColumnName(column).toLowerCase();
+      for (int i = columnCount; i > 0; i--) {
+         columnNames[i - 1] = metaData.getColumnName(i).toLowerCase();
       }
 
       try (final ResultSet closeRS = resultSet) {
@@ -89,6 +92,7 @@ public class OrmReader extends OrmBase
                final String columnName = columnNames[column - 1];
                final AttributeInfo fcInfo = introspected.getFieldColumnInfo(columnName);
                if (fcInfo.isSelfJoinField()) {
+                  fcInfo.setValue(target, columnValue);
                   deferredSelfJoinFkMap.put(target, columnValue);
                }
                else {
@@ -177,7 +181,8 @@ public class OrmReader extends OrmBase
          if (columnValue == null) {
             continue;
          }
-         introspected.set(target, introspected.getFieldColumnInfo(columnName), columnValue);
+         AttributeInfo fcInfo = introspected.getFieldColumnInfo(columnName);
+         introspected.set(target, fcInfo, columnValue);
       }
       return target;
    }

--- a/src/main/java/com/zaxxer/sansorm/internal/OrmWriter.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/OrmWriter.java
@@ -101,25 +101,25 @@ public class OrmWriter extends OrmBase
       }
 
       // If there is a self-referencing column, update it with the generated IDs
-      if (hasSelfJoinColumn) {
-         final AttributeInfo selfJoinfcInfo = introspected.getSelfJoinColumnInfo();
-         final String idColumn = idColumnNames[0];
-         final StringBuilder sql = new StringBuilder("UPDATE ").append(introspected.getTableName())
-            .append(" SET ").append(selfJoinfcInfo.getDelimitedColumnName())
-            .append("=? WHERE ").append(idColumn).append("=?");
-         try (final PreparedStatement stmt = connection.prepareStatement(sql.toString())) {
-            for (final T item : iterable) {
-               final Object referencedItem = introspected.get(item, selfJoinfcInfo);
-               if (referencedItem != null) {
-                  stmt.setObject(1, introspected.getActualIds(referencedItem)[0]);
-                  stmt.setObject(2, introspected.getActualIds(item)[0]);
-                  stmt.addBatch();
-                  stmt.clearParameters();
-               }
-            }
-            stmt.executeBatch();
-         }
-      }
+//      if (hasSelfJoinColumn) {
+//         final AttributeInfo selfJoinfcInfo = introspected.getSelfJoinColumnInfo();
+//         final String idColumn = idColumnNames[0];
+//         final StringBuilder sql = new StringBuilder("UPDATE ").append(introspected.getTableName())
+//            .append(" SET ").append(selfJoinfcInfo.getDelimitedColumnName())
+//            .append("=? WHERE ").append(idColumn).append("=?");
+//         try (final PreparedStatement stmt = connection.prepareStatement(sql.toString())) {
+//            for (final T item : iterable) {
+//               final Object referencedItem = introspected.get(item, selfJoinfcInfo);
+//               if (referencedItem != null) {
+//                  stmt.setObject(1, introspected.getActualIds(referencedItem)[0]);
+//                  stmt.setObject(2, introspected.getActualIds(item)[0]);
+//                  stmt.addBatch();
+//                  stmt.clearParameters();
+//               }
+//            }
+//            stmt.executeBatch();
+//         }
+//      }
    }
 
    public static <T> T insertObject(final Connection connection, final T target) throws SQLException

--- a/src/main/java/com/zaxxer/sansorm/internal/PropertyInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/PropertyInfo.java
@@ -1,0 +1,104 @@
+package com.zaxxer.sansorm.internal;
+
+import javax.persistence.*;
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * "It is required that the entity class follow the method signature conventions for JavaBeans read/write properties (as defined by the JavaBeans Introspector class) for persistent properties when property access is used.” (JSR 317: JavaTM Persistence API, Version 2.0, 2.2 Persistent Fields and Properties)
+ *
+ * @author Holger Thurow (thurow.h@gmail.com)
+ * @since 23.04.18
+ */
+public class PropertyInfo extends AttributeInfo {
+
+   private PropertyDescriptor propertyDescriptor;
+   private boolean toBeConsidered;
+   private Method readMethod;
+
+   public PropertyInfo(Field field, Class clazz) {
+      super(field, clazz);
+   }
+
+   protected void extractFieldName(Field field) {
+      try {
+         propertyDescriptor = new PropertyDescriptor(field.getName(), clazz);
+         readMethod = propertyDescriptor.getReadMethod();
+         name = propertyDescriptor.getName();
+         toBeConsidered = true;
+      }
+      catch (IntrospectionException ignored) {
+         // In case of fields with no getters/setters according to JavaBean conventions.
+         // Set name or NPE in setColumnName(String) will be thrown.
+         name = field.getName();
+      }
+   }
+
+   @Override
+   protected Transient extractTransientAnnotation() {
+      return readMethod.getAnnotation(Transient.class);
+   }
+
+   @Override
+   protected JoinColumn extractJoinColumnAnnotation() {
+      return readMethod.getAnnotation(JoinColumn.class);
+   }
+
+   @Override
+   protected Enumerated extractEnumeratedAnnotation() {
+      return readMethod.getAnnotation(Enumerated.class);
+   }
+
+   @Override
+   protected GeneratedValue extractGeneratedValueAnnotation() {
+      return readMethod.getAnnotation(GeneratedValue.class);
+   }
+
+   @Override
+   protected Id extractIdAnnotation() {
+      return readMethod.getAnnotation(Id.class);
+   }
+
+   @Override
+   protected Convert extractConvertAnnotation() {
+      return readMethod.getAnnotation(Convert.class);
+   }
+
+   @Override
+   protected Column extractColumnAnnotation() {
+      return readMethod.getAnnotation(Column.class);
+   }
+
+   public Object getValue(Object target) throws IllegalAccessException, InvocationTargetException {
+      return readMethod.invoke(target);
+   }
+
+   public void setValue(Object target, Object value) throws IllegalAccessException {
+      try {
+         propertyDescriptor.getWriteMethod().invoke(target, value);
+      }
+      catch (InvocationTargetException e) {
+         e.printStackTrace();
+         throw new RuntimeException(e);
+      }
+   }
+
+   @Override
+   boolean isToBeConsidered() {
+      return toBeConsidered && !isTransient;
+   }
+
+   protected void processJoinColumnAnnotation() {
+      try {
+         super.processJoinColumnAnnotation();
+      }
+      catch (Exception ignored) {
+         // ignore java.lang.RuntimeException: JoinColumn annotations can only be self-referencing
+         toBeConsidered = false;
+      }
+   }
+
+}

--- a/src/main/java/com/zaxxer/sansorm/internal/PropertyInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/PropertyInfo.java
@@ -100,14 +100,7 @@ public class PropertyInfo extends AttributeInfo {
          return readMethod.invoke(target);
       }
       Object obj = readMethod.invoke(target);
-      if (obj != null) {
-         final Introspected introspected = new Introspected(obj.getClass());
-         final AttributeInfo generatedIdFcInfo = introspected.getGeneratedIdFcInfo();
-         return generatedIdFcInfo.getValue(obj);
-      }
-      else {
-         return null;
-      }
+      return extractIdentityFromParent(obj);
    }
 
    public void setValue(final Object target, final Object value) throws IllegalAccessException {
@@ -116,10 +109,7 @@ public class PropertyInfo extends AttributeInfo {
             propertyDescriptor.getWriteMethod().invoke(target, value);
          }
          else {
-            final Object obj = target.getClass().newInstance();
-            final Introspected introspected = new Introspected(obj.getClass());
-            final AttributeInfo generatedIdFcInfo = introspected.getGeneratedIdFcInfo();
-            generatedIdFcInfo.setValue(obj, value);
+            final Object obj = idValueToParent(target, value);
             propertyDescriptor.getWriteMethod().invoke(target, obj);
          }
       }

--- a/src/main/java/com/zaxxer/sansorm/internal/PropertyInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/PropertyInfo.java
@@ -22,7 +22,7 @@ public class PropertyInfo extends AttributeInfo {
       super(field, clazz);
    }
 
-   protected void extractFieldName(Field field) {
+   protected void extractFieldName(final Field field) {
       try {
          propertyDescriptor = new PropertyDescriptor(field.getName(), clazz);
          readMethod = propertyDescriptor.getReadMethod();
@@ -95,14 +95,14 @@ public class PropertyInfo extends AttributeInfo {
       return readMethod.getDeclaredAnnotation(Column.class);
    }
 
-   public Object getValue(Object target) throws IllegalAccessException, InvocationTargetException {
+   public Object getValue(final Object target) throws IllegalAccessException, InvocationTargetException {
       if (!isSelfJoinField()) {
          return readMethod.invoke(target);
       }
       Object obj = readMethod.invoke(target);
       if (obj != null) {
-         Introspected introspected = new Introspected(obj.getClass());
-         AttributeInfo generatedIdFcInfo = introspected.getGeneratedIdFcInfo();
+         final Introspected introspected = new Introspected(obj.getClass());
+         final AttributeInfo generatedIdFcInfo = introspected.getGeneratedIdFcInfo();
          return generatedIdFcInfo.getValue(obj);
       }
       else {
@@ -110,15 +110,15 @@ public class PropertyInfo extends AttributeInfo {
       }
    }
 
-   public void setValue(Object target, Object value) throws IllegalAccessException {
+   public void setValue(final Object target, final Object value) throws IllegalAccessException {
       try {
          if (!isSelfJoinField()) {
             propertyDescriptor.getWriteMethod().invoke(target, value);
          }
          else {
-            Object obj = target.getClass().newInstance();
-            Introspected introspected = new Introspected(obj.getClass());
-            AttributeInfo generatedIdFcInfo = introspected.getGeneratedIdFcInfo();
+            final Object obj = target.getClass().newInstance();
+            final Introspected introspected = new Introspected(obj.getClass());
+            final AttributeInfo generatedIdFcInfo = introspected.getGeneratedIdFcInfo();
             generatedIdFcInfo.setValue(obj, value);
             propertyDescriptor.getWriteMethod().invoke(target, obj);
          }

--- a/src/main/java/com/zaxxer/sansorm/internal/PropertyInfo.java
+++ b/src/main/java/com/zaxxer/sansorm/internal/PropertyInfo.java
@@ -100,7 +100,7 @@ public class PropertyInfo extends AttributeInfo {
          return readMethod.invoke(target);
       }
       Object obj = readMethod.invoke(target);
-      return extractIdentityFromParent(obj);
+      return idValueFromParentEntity(obj);
    }
 
    public void setValue(final Object target, final Object value) throws IllegalAccessException {
@@ -109,7 +109,7 @@ public class PropertyInfo extends AttributeInfo {
             propertyDescriptor.getWriteMethod().invoke(target, value);
          }
          else {
-            final Object obj = idValueToParent(target, value);
+            final Object obj = idValueToParentEntity(target, value);
             propertyDescriptor.getWriteMethod().invoke(target, obj);
          }
       }

--- a/src/test/java/com/zaxxer/sansorm/internal/AccessTypePropertyTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/AccessTypePropertyTest.java
@@ -45,6 +45,29 @@ public class AccessTypePropertyTest {
    }
 
    @Test
+   public void explicitPropertyAccessFieldWithoutAccessors() {
+      @Access(value = AccessType.PROPERTY)
+      class Test {
+         private String field;
+         private String fieldWithoutAccessors;
+
+         public String getField() {
+            return field;
+         }
+
+         public void setField(String value) {
+            // To ensure property access
+            this.field = value.toUpperCase();
+         }
+      }
+      Introspected introspected = new Introspected(Test.class);
+      AttributeInfo field = introspected.getFieldColumnInfo("fieldWithoutAccessors");
+      assertNotNull(field);
+      field = introspected.getFieldColumnInfo("field");
+      assertNotNull(field);
+   }
+
+   @Test
    public void inheritedPropertiesSameExplicitAccessType() throws IllegalAccessException {
 
       @MappedSuperclass @Access(value = AccessType.PROPERTY)

--- a/src/test/java/com/zaxxer/sansorm/internal/AccessTypePropertyTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/AccessTypePropertyTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import javax.persistence.*;
-import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.lang.reflect.InvocationTargetException;
@@ -368,25 +367,23 @@ public class AccessTypePropertyTest {
       class Test {
 
          @Access(value = AccessType.FIELD)
-         private int id;
-         private int field;
+         private String id;
+         private String field;
 
-         public int getId() {
-            // To ensure that id is got via property access
-            return 456;
+         public String getId() {
+            return id;
          }
 
-         public void setId(int id) {
-            // To ensure that id is set via property access
-            this.id = 123;
+         public void setId(String id) {
+            this.id = "field set via setter";
          }
 
-         public int getField() {
+         public String getField() {
             return field;
          }
 
-         public void setField(int field) {
-            this.field = field;
+         public void setField(String field) {
+            this.field = "field set via setter";
          }
       }
 
@@ -396,8 +393,10 @@ public class AccessTypePropertyTest {
       AttributeInfo idInfo = introspected.getFieldColumnInfo("id");
       assertEquals(FieldInfo.class, idInfo.getClass());
       Test obj = new Test();
-      idInfo.setValue(obj, 1);
-      assertEquals(1, idInfo.getValue(obj));
+      idInfo.setValue(obj, "changed");
+      assertEquals("changed", obj.getId());
+      fieldInfo.setValue(obj, "changed");
+      assertEquals("field set via setter", obj.getField());
    }
 
    @Test

--- a/src/test/java/com/zaxxer/sansorm/internal/AccessTypePropertyTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/AccessTypePropertyTest.java
@@ -438,7 +438,7 @@ public class AccessTypePropertyTest {
    }
 
    /**
-    * With IntelliJ from database schema reverse engineered Entity. Associations must still be commected out or Introspection throws errors.
+    * With IntelliJ from database schema reverse engineered entity. Associations must still be commected out or Introspection throws errors.
     */
    @Test
    public void annotatedGetters() throws IllegalAccessException {

--- a/src/test/java/com/zaxxer/sansorm/internal/AccessTypePropertyTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/AccessTypePropertyTest.java
@@ -445,7 +445,7 @@ public class AccessTypePropertyTest {
       Introspected introspected = new Introspected(GetterAnnotatedPitMainEntity.class);
       AttributeInfo[] selectableFcInfos = introspected
          .getSelectableFcInfos();
-      Assertions.assertThat(selectableFcInfos).hasSize(8);
+      Assertions.assertThat(selectableFcInfos).hasSize(9);
       Assertions.assertThat(selectableFcInfos).allMatch(attributeInfo -> attributeInfo.getClass() == PropertyInfo.class);
       GetterAnnotatedPitMainEntity entity = new GetterAnnotatedPitMainEntity();
       AttributeInfo pitType = introspected.getFieldColumnInfo("PIT_TYPE");

--- a/src/test/java/com/zaxxer/sansorm/internal/AccessTypePropertyTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/AccessTypePropertyTest.java
@@ -1,0 +1,435 @@
+package com.zaxxer.sansorm.internal;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.persistence.*;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Holger Thurow (thurow.h@gmail.com)
+ * @since 28.04.18
+ */
+public class AccessTypePropertyTest {
+
+   @Rule
+   public ExpectedException thrown = ExpectedException.none();
+
+   @Test
+   public void explicitPropertyAccess() throws IllegalAccessException {
+      @Access(value = AccessType.PROPERTY)
+      class Test {
+         private String field;
+
+         public String getField() {
+            return field;
+         }
+
+         public void setField(String value) {
+            // To ensure property access
+            this.field = value.toUpperCase();
+         }
+      }
+      Introspected introspected = new Introspected(Test.class);
+      AttributeInfo field = introspected.getFieldColumnInfo("field");
+      Test obj = new Test();
+      field.setValue(obj, "changed");
+      assertEquals("CHANGED", obj.getField());
+   }
+
+   @Test
+   public void inheritedPropertiesSameExplicitAccessType() throws IllegalAccessException {
+
+      @MappedSuperclass @Access(value = AccessType.PROPERTY)
+      class Test {
+         private int id;
+
+         public int getId() {
+            return id;
+         }
+
+         public void setId(int id) {
+            // To ensure property access
+            this.id = ++id;
+         }
+      }
+
+      @Access(value = AccessType.PROPERTY)
+      class SubTest extends Test { }
+
+      Introspected introspected = new Introspected(SubTest.class);
+      AttributeInfo field = introspected.getFieldColumnInfo("id");
+      assertEquals(field.getClass(), PropertyInfo.class);
+      SubTest obj = new SubTest();
+      field.setValue(obj, 1);
+      assertEquals(2, obj.getId());
+   }
+
+   /**
+    * "An access type for an individual entity class, mapped superclass, or embeddable class can be specified for that class independent of the default for the entity hierarchy" (JSR 317: JavaTM Persistence API, Version 2.0, Final Release, 2.3.2 Explicit Access Type)
+
+    */
+   @Test
+   public void mixedExplicitAccessType() throws IllegalAccessException, InvocationTargetException {
+
+      @MappedSuperclass @Access(value = AccessType.FIELD)
+      class Test {
+         private int id;
+
+         public void setId(int id) {
+            // To ensure field access (id must be not incremented when id field is set)
+            this.id = ++id;
+         }
+      }
+
+      @Access(value = AccessType.PROPERTY)
+      class SubTest extends Test { }
+
+      Introspected introspected = new Introspected(SubTest.class);
+      AttributeInfo field = introspected.getFieldColumnInfo("id");
+      assertNotNull(field);
+      assertEquals(field.getClass(), FieldInfo.class);
+
+      SubTest obj = new SubTest();
+      field.setValue(obj, 1);
+      assertEquals(1, field.getValue(obj));
+   }
+
+   @Test
+   public void overridenMethodSameExplicitAccessType() throws IllegalAccessException, InvocationTargetException {
+      @MappedSuperclass @Access(value = AccessType.PROPERTY)
+      class Test {
+         private int id;
+
+         public void setId(int id) {
+            // Does nothing to ensure the overriding method was called
+         }
+
+         public int getId() {
+            return id;
+         }
+      }
+
+      @Access(value = AccessType.PROPERTY)
+      class SubTest extends Test {
+         public void setId(int id) {
+            super.id = ++id;
+         }
+      }
+
+      Introspected introspected = new Introspected(SubTest.class);
+      AttributeInfo field = introspected.getFieldColumnInfo("id");
+      assertNotNull(field);
+      assertEquals(field.getClass(), PropertyInfo.class);
+
+      SubTest obj = new SubTest();
+      field.setValue(obj, 1);
+      assertEquals(2, field.getValue(obj));
+   }
+
+   /**
+    * See {@link #mixedExplicitAccessType()} ()}. id must be accessed directly.
+    */
+   @Test
+   public void overridenMethodDifferentExplicitAccessTypes() throws IllegalAccessException, InvocationTargetException {
+      @MappedSuperclass @Access(value = AccessType.FIELD)
+      class Test {
+         private int id;
+
+         public void setId(int id) {
+            this.id = 123;
+         }
+
+         public int getId() {
+            return id;
+         }
+      }
+
+      @Access(value = AccessType.PROPERTY)
+      class SubTest extends Test {
+         public void setId(int id) {
+            super.id = 456;
+         }
+      }
+
+      Introspected introspected = new Introspected(SubTest.class);
+      AttributeInfo field = introspected.getFieldColumnInfo("id");
+      assertNotNull(field);
+      assertEquals(field.getClass(), FieldInfo.class);
+
+      SubTest obj = new SubTest();
+      field.setValue(obj, 1);
+      assertEquals(1, field.getValue(obj));
+   }
+
+   @Test
+   public void defaultPropertyAccess() {
+      class Test {
+         private String field;
+
+         @Basic
+         public String getField() {
+            return field;
+         }
+
+         public void setField(String field) {
+            this.field = field;
+         }
+      }
+
+      Introspected introspected = new Introspected(Test.class);
+      AttributeInfo info = introspected.getFieldColumnInfo("field");
+      assertEquals(PropertyInfo.class, info.getClass());
+   }
+
+   @Test
+   public void defaultFieldAccess() {
+      class Test {
+         @Basic
+         private String field;
+
+         public String getField() {
+            return field;
+         }
+
+         public void setField(String field) {
+            this.field = field;
+         }
+      }
+
+      Introspected introspected = new Introspected(Test.class);
+      AttributeInfo info = introspected.getFieldColumnInfo("field");
+      assertEquals(FieldInfo.class, info.getClass());
+   }
+
+   /**
+    * Neither property nor field access specified.
+    */
+   @Test
+   public void fallbackAccess() {
+      class Test {
+         private String field;
+
+         public String getField() {
+            return field;
+         }
+
+         public void setField(String field) {
+            this.field = field;
+         }
+      }
+
+      Introspected introspected = new Introspected(Test.class);
+      AttributeInfo info = introspected.getFieldColumnInfo("field");
+      assertEquals(FieldInfo.class, info.getClass());
+   }
+
+   /**
+    * "All such classes in the entity hierarchy whose access type is defaulted in this way must be consistent in their placement of annotations on either fields or properties, such that a single, consistent default access type applies within the hierarchy ... It is an error if a default access type cannot be determined and an access type is not explicitly specified by means of annotations or the XML descriptor. The behavior of applications that mix the placement of annotations on fields and properties within an entity hierarchy without explicitly specifying the Access annotation is undefined." (JSR 317: JavaTM Persistence API, Version 2.0, 2.3.1 Default Access Type)
+    */
+   @Test
+   public void mixedDefaultAccessType() {
+
+      @MappedSuperclass
+      class Test {
+         private int id;
+
+         @Id
+         public int getId() {
+            return id;
+         }
+
+         public void setId(int id) {
+            this.id = id;
+         }
+      }
+
+      class SubTest extends Test {
+         @Basic
+         private String field;
+         private String field2;
+      }
+
+      Introspected introspected = new Introspected(SubTest.class);
+      AttributeInfo idInfo = introspected.getFieldColumnInfo("id");
+      assertEquals(PropertyInfo.class, idInfo.getClass());
+      AttributeInfo fieldInfo = introspected.getFieldColumnInfo("field");
+      assertEquals(FieldInfo.class, fieldInfo.getClass());
+   }
+
+   /**
+    * See {@link #ambiguousAccessType()}.
+    */
+   @Test
+   public void mixedDefaultAccessType2() {
+
+      @MappedSuperclass
+      class Test {
+         private int id;
+
+         @Id
+         public int getId() {
+            return id;
+         }
+
+         public void setId(int id) {
+            this.id = id;
+         }
+      }
+
+      class SubTest extends Test {
+         @Basic
+         private String field;
+         private String field2;
+
+         @Access(value = AccessType.PROPERTY)
+         public String getField2() {
+            return "property access";
+         }
+
+         public void setField2(String field2) {
+            this.field2 = field2;
+         }
+      }
+
+      Introspected introspected = new Introspected(SubTest.class);
+      AttributeInfo idInfo = introspected.getFieldColumnInfo("id");
+      assertEquals(PropertyInfo.class, idInfo.getClass());
+      AttributeInfo fieldInfo = introspected.getFieldColumnInfo("field");
+      assertEquals(FieldInfo.class, fieldInfo.getClass());
+      AttributeInfo field2Info = introspected.getFieldColumnInfo("field2");
+      assertEquals(FieldInfo.class, field2Info.getClass());
+   }
+
+   /**
+    * See {@link #mixedDefaultAccessType()}. When the access type of a single class is ambiguous SansOrm defaults to field access.
+    */
+   @Test
+   public void ambiguousAccessType() {
+
+      class Test {
+
+         private int id;
+
+         @Column
+         private int field;
+
+         public void setId(int id) {
+            this.id = 123;
+         }
+
+         @Column
+         public int getId() {
+            return id;
+         }
+      }
+
+      Introspected introspected = new Introspected(Test.class);
+      AttributeInfo fieldInfo = introspected.getFieldColumnInfo("field");
+      assertEquals(FieldInfo.class, fieldInfo.getClass());
+      AttributeInfo idInfo = introspected.getFieldColumnInfo("id");
+      assertEquals(FieldInfo.class, idInfo.getClass());
+   }
+
+   @Test
+   public void explicitAccessTypeWithFieldSpecificOne() throws IllegalAccessException, InvocationTargetException {
+
+      @Access(value = AccessType.PROPERTY)
+      class Test {
+
+         @Access(value = AccessType.FIELD)
+         private int id;
+         private int field;
+
+         public int getId() {
+            // To ensure that id is got via property access
+            return 456;
+         }
+
+         public void setId(int id) {
+            // To ensure that id is set via property access
+            this.id = 123;
+         }
+
+         public int getField() {
+            return field;
+         }
+
+         public void setField(int field) {
+            this.field = field;
+         }
+      }
+
+      Introspected introspected = new Introspected(Test.class);
+      AttributeInfo fieldInfo = introspected.getFieldColumnInfo("field");
+      assertEquals(PropertyInfo.class, fieldInfo.getClass());
+      AttributeInfo idInfo = introspected.getFieldColumnInfo("id");
+      assertEquals(FieldInfo.class, idInfo.getClass());
+      Test obj = new Test();
+      idInfo.setValue(obj, 1);
+      assertEquals(1, idInfo.getValue(obj));
+   }
+
+   @Test
+   public void illegalAnnotationOnProperty() {
+      @Access(value = AccessType.PROPERTY)
+      class Test {
+         private int id;
+
+         @Access(value = AccessType.FIELD)
+         public int getId() {
+            return id;
+         }
+
+         public void setId(int id) {
+            this.id = id;
+         }
+      }
+      thrown.expectMessage("A method can not be of access type field");
+      Introspected introspected = new Introspected(Test.class);
+   }
+
+   @Test
+   public void illegalAnnotationOnField() {
+      @Access(value = AccessType.FIELD)
+      class Test {
+         @Access(value = AccessType.PROPERTY)
+         private int id;
+
+         public int getId() {
+            return id;
+         }
+
+         public void setId(int id) {
+            this.id = id;
+         }
+      }
+      thrown.expectMessage("A field can not be of access type property");
+      Introspected introspected = new Introspected(Test.class);
+   }
+
+   /**
+    * With IntelliJ from database schema reverse engineered Entity. Associations must still be commected out or Introspection throws errors.
+    */
+   @Test
+   public void annotatedGetters() throws IllegalAccessException {
+      Introspected introspected = new Introspected(GetterAnnotatedPitMainEntity.class);
+      AttributeInfo[] selectableFcInfos = introspected
+         .getSelectableFcInfos();
+      Assertions.assertThat(selectableFcInfos).hasSize(8);
+      Assertions.assertThat(selectableFcInfos).allMatch(attributeInfo -> attributeInfo.getClass() == PropertyInfo.class);
+      GetterAnnotatedPitMainEntity entity = new GetterAnnotatedPitMainEntity();
+      AttributeInfo pitType = introspected.getFieldColumnInfo("PIT_TYPE");
+      pitType.setValue(entity, "changed");
+      assertEquals("changed", entity.getPitType());
+
+   }
+
+   // TODO test property change listener support
+}

--- a/src/test/java/com/zaxxer/sansorm/internal/FieldColumnInfoTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/FieldColumnInfoTest.java
@@ -21,7 +21,7 @@ public class FieldColumnInfoTest {
          String field;
       }
       Introspected introspected = new Introspected(TestClass.class);
-      FieldColumnInfo[] fcInfos = introspected.getSelectableFcInfos();
+      AttributeInfo[] fcInfos = introspected.getSelectableFcInfos();
       String fqn = fcInfos[0].getFullyQualifiedDelimitedFieldName();
       assertEquals("TEST_CLASS.field", fqn);
    }

--- a/src/test/java/com/zaxxer/sansorm/internal/GetterAnnotatedPitMainEntity.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/GetterAnnotatedPitMainEntity.java
@@ -1,0 +1,186 @@
+package com.zaxxer.sansorm.internal;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+import java.util.Collection;
+
+/**
+ * @author Holger Thurow (thurow.h@gmail.com)
+ * @since 24.04.18
+ */
+@Entity
+@Table(name = "D_PIT_MAIN", schema = "dbo", catalog = "xxxxxxxxx")
+public class GetterAnnotatedPitMainEntity {
+
+   private int pitIdent;
+   private Timestamp pitCrdate;
+   private Timestamp pitChgDate;
+   private String pitType;
+   private String pitVisibility;
+   private String pitNote;
+   private String pitUser;
+   private Timestamp pitRejectedDate;
+//   private GetterAnnotatedPitMainEntity pitMainByPitIdent;
+//   private Collection<GetterAnnotatedPitMainEntity> notes;
+//   private GetterAnnotatedPitReferenceEntity pitReferenceByPitIdent;
+
+   @Id @Basic @Column(name = "PIT_IDENT")
+   public int getPitIdent() {
+      return pitIdent;
+   }
+
+   public void setPitIdent(int pitIdent) {
+      this.pitIdent = pitIdent;
+   }
+
+   @Basic
+   @Column(name = "PIT_CRDATE")
+   public Timestamp getPitCrdate() {
+      return pitCrdate;
+   }
+
+   public void setPitCrdate(Timestamp pitCrdate) {
+      this.pitCrdate = pitCrdate;
+   }
+
+   @Basic
+   @Column(name = "PIT_CHG_DATE")
+   public Timestamp getPitChgDate() {
+      return pitChgDate;
+   }
+
+   public void setPitChgDate(Timestamp pitChgDate) {
+      this.pitChgDate = pitChgDate;
+   }
+
+   @Basic
+   @Column(name = "PIT_TYPE")
+   public String getPitType() {
+      return pitType;
+   }
+
+   public void setPitType(String pitType) {
+      this.pitType = pitType;
+   }
+
+   @Basic
+   @Column(name = "PIT_VISIBILITY")
+   public String getPitVisibility() {
+      return pitVisibility;
+   }
+
+   public void setPitVisibility(String pitVisibility) {
+      this.pitVisibility = pitVisibility;
+   }
+
+   @Basic
+   @Column(name = "PIT_NOTE")
+   public String getPitNote() {
+      return pitNote;
+   }
+
+   public void setPitNote(String pitNote) {
+      this.pitNote = pitNote;
+   }
+
+   @Basic
+   @Column(name = "PIT_USER")
+   public String getPitUser() {
+      return pitUser;
+   }
+
+   public void setPitUser(String pitUser) {
+      this.pitUser = pitUser;
+   }
+
+   @Basic
+   @Column(name = "PIT_REJECTED_DATE")
+   public Timestamp getPitRejectedDate() {
+      return pitRejectedDate;
+   }
+
+   public void setPitRejectedDate(Timestamp pitRejectedDate) {
+      this.pitRejectedDate = pitRejectedDate;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      GetterAnnotatedPitMainEntity that = (GetterAnnotatedPitMainEntity) o;
+
+      if (pitIdent != that.pitIdent) {
+         return false;
+      }
+      if (pitCrdate != null ? !pitCrdate.equals(that.pitCrdate) : that.pitCrdate != null) {
+         return false;
+      }
+      if (pitChgDate != null ? !pitChgDate.equals(that.pitChgDate) : that.pitChgDate != null) {
+         return false;
+      }
+      if (pitType != null ? !pitType.equals(that.pitType) : that.pitType != null) {
+         return false;
+      }
+      if (pitVisibility != null ? !pitVisibility.equals(that.pitVisibility) : that.pitVisibility != null) {
+         return false;
+      }
+      if (pitNote != null ? !pitNote.equals(that.pitNote) : that.pitNote != null) {
+         return false;
+      }
+      if (pitUser != null ? !pitUser.equals(that.pitUser) : that.pitUser != null) {
+         return false;
+      }
+      if (pitRejectedDate != null ? !pitRejectedDate.equals(that.pitRejectedDate) : that.pitRejectedDate != null) {
+         return false;
+      }
+
+      return true;
+   }
+
+   @Override
+   public int hashCode() {
+      int result = pitIdent;
+      result = 31 * result + (pitCrdate != null ? pitCrdate.hashCode() : 0);
+      result = 31 * result + (pitChgDate != null ? pitChgDate.hashCode() : 0);
+      result = 31 * result + (pitType != null ? pitType.hashCode() : 0);
+      result = 31 * result + (pitVisibility != null ? pitVisibility.hashCode() : 0);
+      result = 31 * result + (pitNote != null ? pitNote.hashCode() : 0);
+      result = 31 * result + (pitUser != null ? pitUser.hashCode() : 0);
+      result = 31 * result + (pitRejectedDate != null ? pitRejectedDate.hashCode() : 0);
+      return result;
+   }
+
+//   @ManyToOne
+//   @JoinColumn(name = "PIT_IDENT", referencedColumnName = "PIT_PARENT_ID", nullable = false)
+//   public GetterAnnotatedPitMainEntity getPitMainByPitIdent() {
+//      return pitMainByPitIdent;
+//   }
+//
+//   public void setPitMainByPitIdent(GetterAnnotatedPitMainEntity pitMainByPitIdent) {
+//      this.pitMainByPitIdent = pitMainByPitIdent;
+//   }
+//
+//   @OneToMany(mappedBy = "pitMainByPitIdent")
+//   public Collection<GetterAnnotatedPitMainEntity> getNotes() {
+//      return notes;
+//   }
+//
+//   public void setNotes(Collection<GetterAnnotatedPitMainEntity> notes) {
+//      this.notes = notes;
+//   }
+//
+//   @ManyToOne
+//   @JoinColumn(name = "PIT_IDENT", referencedColumnName = "PIR_PIT_IDENT", nullable = false)
+//   public GetterAnnotatedPitReferenceEntity getPitReferenceByPitIdent() {
+//      return pitReferenceByPitIdent;
+//   }
+//
+//   public void setPitReferenceByPitIdent(GetterAnnotatedPitReferenceEntity pitReferenceByPitIdent) {
+//      this.pitReferenceByPitIdent = pitReferenceByPitIdent;
+//   }
+}

--- a/src/test/java/com/zaxxer/sansorm/internal/GetterAnnotatedPitMainEntity.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/GetterAnnotatedPitMainEntity.java
@@ -156,7 +156,7 @@ public class GetterAnnotatedPitMainEntity {
    }
 
    @ManyToOne
-   @JoinColumn(name = "PIT_IDENT", referencedColumnName = "PIT_PARENT_ID", nullable = false)
+   @JoinColumn(name = "PIT_PARENT_ID", referencedColumnName = "PIT_IDENT", nullable = false)
    public GetterAnnotatedPitMainEntity getPitMainByPitIdent() {
       return pitMainByPitIdent;
    }

--- a/src/test/java/com/zaxxer/sansorm/internal/GetterAnnotatedPitMainEntity.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/GetterAnnotatedPitMainEntity.java
@@ -20,9 +20,9 @@ public class GetterAnnotatedPitMainEntity {
    private String pitNote;
    private String pitUser;
    private Timestamp pitRejectedDate;
-//   private GetterAnnotatedPitMainEntity pitMainByPitIdent;
-//   private Collection<GetterAnnotatedPitMainEntity> notes;
-//   private GetterAnnotatedPitReferenceEntity pitReferenceByPitIdent;
+   private GetterAnnotatedPitMainEntity pitMainByPitIdent;
+   private Collection<GetterAnnotatedPitMainEntity> notes;
+   private GetterAnnotatedPitReferenceEntity pitReferenceByPitIdent;
 
    @Id @Basic @Column(name = "PIT_IDENT")
    public int getPitIdent() {
@@ -155,32 +155,32 @@ public class GetterAnnotatedPitMainEntity {
       return result;
    }
 
-//   @ManyToOne
-//   @JoinColumn(name = "PIT_IDENT", referencedColumnName = "PIT_PARENT_ID", nullable = false)
-//   public GetterAnnotatedPitMainEntity getPitMainByPitIdent() {
-//      return pitMainByPitIdent;
-//   }
-//
-//   public void setPitMainByPitIdent(GetterAnnotatedPitMainEntity pitMainByPitIdent) {
-//      this.pitMainByPitIdent = pitMainByPitIdent;
-//   }
-//
-//   @OneToMany(mappedBy = "pitMainByPitIdent")
-//   public Collection<GetterAnnotatedPitMainEntity> getNotes() {
-//      return notes;
-//   }
-//
-//   public void setNotes(Collection<GetterAnnotatedPitMainEntity> notes) {
-//      this.notes = notes;
-//   }
-//
-//   @ManyToOne
-//   @JoinColumn(name = "PIT_IDENT", referencedColumnName = "PIR_PIT_IDENT", nullable = false)
-//   public GetterAnnotatedPitReferenceEntity getPitReferenceByPitIdent() {
-//      return pitReferenceByPitIdent;
-//   }
-//
-//   public void setPitReferenceByPitIdent(GetterAnnotatedPitReferenceEntity pitReferenceByPitIdent) {
-//      this.pitReferenceByPitIdent = pitReferenceByPitIdent;
-//   }
+   @ManyToOne
+   @JoinColumn(name = "PIT_IDENT", referencedColumnName = "PIT_PARENT_ID", nullable = false)
+   public GetterAnnotatedPitMainEntity getPitMainByPitIdent() {
+      return pitMainByPitIdent;
+   }
+
+   public void setPitMainByPitIdent(GetterAnnotatedPitMainEntity pitMainByPitIdent) {
+      this.pitMainByPitIdent = pitMainByPitIdent;
+   }
+
+   @OneToMany(mappedBy = "pitMainByPitIdent")
+   public Collection<GetterAnnotatedPitMainEntity> getNotes() {
+      return notes;
+   }
+
+   public void setNotes(Collection<GetterAnnotatedPitMainEntity> notes) {
+      this.notes = notes;
+   }
+
+   @ManyToOne
+   @JoinColumn(name = "PIT_IDENT", referencedColumnName = "PIR_PIT_IDENT", nullable = false)
+   public GetterAnnotatedPitReferenceEntity getPitReferenceByPitIdent() {
+      return pitReferenceByPitIdent;
+   }
+
+   public void setPitReferenceByPitIdent(GetterAnnotatedPitReferenceEntity pitReferenceByPitIdent) {
+      this.pitReferenceByPitIdent = pitReferenceByPitIdent;
+   }
 }

--- a/src/test/java/com/zaxxer/sansorm/internal/GetterAnnotatedPitReferenceEntity.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/GetterAnnotatedPitReferenceEntity.java
@@ -1,0 +1,87 @@
+package com.zaxxer.sansorm.internal;
+
+import javax.persistence.*;
+import java.util.Collection;
+
+/**
+ * @author Holger Thurow (thurow.h@gmail.com)
+ * @since 24.04.18
+ */
+@Entity
+@Table(name = "D_PIT_REFERENCE", schema = "dbo", catalog = "xxxxxxxxx")
+public class GetterAnnotatedPitReferenceEntity {
+
+   private int pirPitIdent;
+   private int pirRefId;
+   private int pirTnsTableId;
+   private Collection<GetterAnnotatedPitMainEntity> notes;
+
+   @Id @Basic @Column(name = "PIR_PIT_IDENT")
+   public int getPirPitIdent() {
+      return pirPitIdent;
+   }
+
+   public void setPirPitIdent(int pirPitIdent) {
+      this.pirPitIdent = pirPitIdent;
+   }
+
+   @Basic
+   @Column(name = "PIR_REF_ID")
+   public int getPirRefId() {
+      return pirRefId;
+   }
+
+   public void setPirRefId(int pirRefId) {
+      this.pirRefId = pirRefId;
+   }
+
+   @Id @Basic @Column(name = "PIR_TNS_TABLE_ID")
+   public int getPirTnsTableId() {
+      return pirTnsTableId;
+   }
+
+   public void setPirTnsTableId(int pirTnsTableId) {
+      this.pirTnsTableId = pirTnsTableId;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      GetterAnnotatedPitReferenceEntity that = (GetterAnnotatedPitReferenceEntity) o;
+
+      if (pirPitIdent != that.pirPitIdent) {
+         return false;
+      }
+      if (pirRefId != that.pirRefId) {
+         return false;
+      }
+      if (pirTnsTableId != that.pirTnsTableId) {
+         return false;
+      }
+
+      return true;
+   }
+
+   @Override
+   public int hashCode() {
+      int result = pirPitIdent;
+      result = 31 * result + pirRefId;
+      result = 31 * result + pirTnsTableId;
+      return result;
+   }
+
+   @OneToMany(mappedBy = "pitReferenceByPitIdent")
+   public Collection<GetterAnnotatedPitMainEntity> getNotes() {
+      return notes;
+   }
+
+   public void setNotes(Collection<GetterAnnotatedPitMainEntity> notes) {
+      this.notes = notes;
+   }
+}

--- a/src/test/java/com/zaxxer/sansorm/internal/IntrospectedTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/IntrospectedTest.java
@@ -1,17 +1,17 @@
 package com.zaxxer.sansorm.internal;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.sansorm.TargetClass1;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.MappedSuperclass;
-import javax.persistence.Table;
+import javax.persistence.*;
+
+import java.util.ArrayList;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class IntrospectedTest
 {
@@ -157,6 +157,35 @@ public class IntrospectedTest
       assertThat(inspected.getIdColumnNames()).isEqualTo(new String[]{"id"});
       // 15.04.18: Was case insensitive lexicographic order ("id", "string"). Now order as fields were supplied by inspection.
       assertThat(inspected.getColumnNames()).isEqualTo(new String[]{"string2", "string", "id"});
+   }
+
+   @Test
+   public void accessTypeClass() {
+      @Access(value = AccessType.FIELD)
+      class Entity { }
+      Introspected introspected = new Introspected(Entity.class);
+      assertTrue(introspected.isExplicitFieldAccess(Entity.class));
+      assertFalse(introspected.isExplicitPropertyAccess(Entity.class));
+   }
+
+   @Test
+   public void accessTypeClassNotSpecified() {
+      class Entity { }
+      Introspected introspected = new Introspected(Entity.class);
+      assertFalse(introspected.isExplicitFieldAccess(Entity.class));
+      assertFalse(introspected.isExplicitPropertyAccess(Entity.class));
+   }
+
+   /**
+    * See <a href="https://github.com/brettwooldridge/SansOrm/commit/33208797e55cd7a3375dabe332f5518779188ab3">Fix NPE dereferencing fcInfo.isInsertable() as boolean</a>
+    */
+   @Test
+   public void noColumnAnnotation() {
+      class Test {
+         private String field;
+      }
+      Introspected introspected = new Introspected(Test.class);
+      assertEquals(1, introspected.getColumnNames().length);
    }
 
 }

--- a/src/test/java/com/zaxxer/sansorm/internal/PropertyDescriptorTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/PropertyDescriptorTest.java
@@ -1,0 +1,95 @@
+package com.zaxxer.sansorm.internal;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.persistence.Column;
+import java.beans.*;
+import java.beans.Introspector;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+/**
+ * Bean Methoden müssen public sein.
+ * Introspector liefert alle Methoden der Bean, die public sind, nicht nur getter und setter.
+ *
+ * @author Holger Thurow (thurow.h@gmail.com)
+ * @since 28.04.18
+ */
+public class PropertyDescriptorTest {
+
+   @Rule
+   public ExpectedException thrown = ExpectedException.none();
+
+   @Test
+   public void stringProperty() throws IntrospectionException, InvocationTargetException, IllegalAccessException {
+      PropertyDescriptor descriptor = new PropertyDescriptor("field", PropertyDescriptorTestClass.class);
+      Method getter = descriptor.getReadMethod();
+      assertEquals("public java.lang.String com.zaxxer.sansorm.internal.PropertyDescriptorTestClass.getField()", getter.toString());
+      PropertyDescriptorTestClass obj = new PropertyDescriptorTestClass();
+      obj.setField("value");
+      assertEquals("value", getter.invoke(obj));
+   }
+
+   @Test
+   public void nonSpecConformMethodSignature() throws IntrospectionException, InvocationTargetException, IllegalAccessException {
+      thrown.expectMessage("Method not found: isIsBoolean");
+      PropertyDescriptor descriptor = new PropertyDescriptor("isBoolean", PropertyDescriptorTestClass.class);
+   }
+
+   @Test
+   public void booleanProperty() throws IntrospectionException, InvocationTargetException, IllegalAccessException {
+      PropertyDescriptor descriptor = new PropertyDescriptor("stored", PropertyDescriptorTestClass.class);
+      Method getter = descriptor.getReadMethod();
+      PropertyDescriptorTestClass obj = new PropertyDescriptorTestClass();
+      obj.setStored(true);
+      assertEquals(true, getter.invoke(obj));
+   }
+
+   @Test
+   public void packagePrivate() throws IntrospectionException, InvocationTargetException, IllegalAccessException {
+      PropertyDescriptor descriptor = new PropertyDescriptor("packagePrivate", PropertyDescriptorTestClass.class);
+      Method getter = descriptor.getReadMethod();
+      PropertyDescriptorTestClass obj = new PropertyDescriptorTestClass();
+      obj.setPackagePrivate(1);
+      assertEquals(1, getter.invoke(obj));
+      assertTrue(descriptor.getPropertyType() == int.class);
+   }
+
+   @Test
+   public void protectedProperty() throws IntrospectionException, InvocationTargetException, IllegalAccessException {
+      PropertyDescriptor descriptor = new PropertyDescriptor("protectedProperty", PropertyDescriptorTestClass.class);
+      Method getter = descriptor.getReadMethod();
+      PropertyDescriptorTestClass obj = new PropertyDescriptorTestClass();
+      obj.setProtectedProperty("y");
+      assertEquals("y", getter.invoke(obj));
+      assertTrue(descriptor.getPropertyType() == String.class);
+   }
+
+   @Test
+   public void getMethodDescriptors() throws IntrospectionException {
+      BeanInfo beanInfo = Introspector.getBeanInfo(PropertyDescriptorTestClass.class);
+      MethodDescriptor[] methodDescriptors = beanInfo.getMethodDescriptors();
+      Arrays.stream(methodDescriptors).forEach(descriptor -> {
+         System.out.println(descriptor);
+      });
+   }
+
+   /**
+    * fields ohne Getter/Setter werden nicht geliefert
+    */
+   @Test
+   public void getPropertyDescriptors() throws IntrospectionException {
+      class Test {
+         private String field;
+      }
+      BeanInfo beanInfo = Introspector.getBeanInfo(Test.class);
+      PropertyDescriptor[] descriptors = beanInfo.getPropertyDescriptors();
+      assertEquals(1, descriptors.length);
+      assertEquals("class", descriptors[0].getName());
+   }
+}

--- a/src/test/java/com/zaxxer/sansorm/internal/PropertyDescriptorTestClass.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/PropertyDescriptorTestClass.java
@@ -1,0 +1,70 @@
+package com.zaxxer.sansorm.internal;
+
+import javax.persistence.Column;
+
+/**
+ * @author Holger Thurow (thurow.h@gmail.com)
+ * @since 28.04.18
+ */
+public class PropertyDescriptorTestClass {
+   private String field;
+   private boolean isBoolean;
+   private boolean stored;
+   int packagePrivate;
+   protected String protectedProperty;
+
+
+
+   @Column
+   public String getField() {
+      return field;
+   }
+
+   public void setField(String field) {
+      this.field = field;
+   }
+
+   public boolean isBoolean() {
+      return isBoolean;
+   }
+
+   public void setBoolean(boolean aBoolean) {
+      isBoolean = aBoolean;
+   }
+
+   public boolean isStored() {
+      return stored;
+   }
+
+   public void setStored(boolean stored) {
+      this.stored = stored;
+   }
+
+   public int getPackagePrivate() {
+      return packagePrivate;
+   }
+
+   public void setPackagePrivate(int packagePrivate) {
+      this.packagePrivate = packagePrivate;
+   }
+
+   public String getProtectedProperty() {
+      return protectedProperty;
+   }
+
+   public void setProtectedProperty(String protectedProperty) {
+      this.protectedProperty = protectedProperty;
+   }
+
+   public void isNoSetter(String s) {
+
+   }
+
+   public void isNoSetterOrGetter() {
+
+   }
+
+   protected void isNoSetterProtected() {
+
+   }
+}

--- a/src/test/java/com/zaxxer/sansorm/internal/PropertyInfoTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/PropertyInfoTest.java
@@ -47,7 +47,21 @@ public class PropertyInfoTest {
       assertEquals("field", fieldAccessor.getName());
 //      thrown.expectMessage("FieldInfo can not access a member of class com.zaxxer.sansorm.internal.PropertyInfoTest$2Test with modifiers \"private\"");
       assertEquals(null, fieldAccessor.getValue(target));
+   }
 
+   @Test
+   public void selfJoinColumnPropertyAccess() throws NoSuchFieldException, IllegalAccessException, InvocationTargetException {
+      GetterAnnotatedPitMainEntity entity = new GetterAnnotatedPitMainEntity();
+      Field joinField = entity.getClass().getDeclaredField("pitMainByPitIdent");
+      PropertyInfo joinFieldInfo = new PropertyInfo(joinField, entity.getClass());
 
+      // transform id value read from table into entity
+      joinFieldInfo.setValue(entity, 1);
+      GetterAnnotatedPitMainEntity parentEntity = entity.getPitMainByPitIdent();
+      assertNotNull(parentEntity);
+      assertEquals(1, parentEntity.getPitIdent());
+
+      // transform entity into id value to store id in table
+      assertEquals(1, joinFieldInfo.getValue(entity));
    }
 }

--- a/src/test/java/com/zaxxer/sansorm/internal/PropertyInfoTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/PropertyInfoTest.java
@@ -1,0 +1,53 @@
+package com.zaxxer.sansorm.internal;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Holger Thurow (thurow.h@gmail.com)
+ * @since 28.04.18
+ */
+public class PropertyInfoTest {
+
+   @Rule
+   public ExpectedException thrown = ExpectedException.none();
+
+   @Test
+   public void privateFieldWithGetterSetter() throws InvocationTargetException, IllegalAccessException {
+      class Test {
+         private String field;
+
+         public String getField() {
+            return field;
+         }
+
+         public void setField(String value) {
+            this.field = value;
+         }
+      }
+      Field[] declaredFields = Test.class.getDeclaredFields();
+      PropertyInfo propertyAccessor = new PropertyInfo(declaredFields[0], Test.class);
+      assertTrue(propertyAccessor.isToBeConsidered());
+      assertEquals("field", propertyAccessor.getName());
+      Test target = new Test();
+      assertEquals(null, propertyAccessor.getValue(target));
+      target.setField("test");
+      assertEquals("test", propertyAccessor.getValue(target));
+      propertyAccessor.setValue(target, null);
+      assertEquals(null, target.getField());
+
+      FieldInfo fieldAccessor = new FieldInfo(declaredFields[0], Test.class);
+      assertTrue(fieldAccessor.isToBeConsidered());
+      assertEquals("field", fieldAccessor.getName());
+//      thrown.expectMessage("FieldInfo can not access a member of class com.zaxxer.sansorm.internal.PropertyInfoTest$2Test with modifiers \"private\"");
+      assertEquals(null, fieldAccessor.getValue(target));
+
+
+   }
+}

--- a/src/test/java/com/zaxxer/sansorm/internal/SelfJoinManyToOneFieldAccessTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/SelfJoinManyToOneFieldAccessTest.java
@@ -51,57 +51,6 @@ public class SelfJoinManyToOneFieldAccessTest {
    }
 
    @Test
-   public void selfJoinColumnFieldAccessH2() throws SQLException {
-
-      JdbcDataSource ds = TestUtils.makeH2DataSource();
-      SansOrm.initializeTxNone(ds);
-      try (Connection con = ds.getConnection()){
-         SqlClosureElf.executeUpdate(
-            " CREATE TABLE JOINTEST (" +
-               " "
-               + "id INTEGER NOT NULL IDENTITY PRIMARY KEY"
-               + ", parentId INTEGER"
-               + ", type VARCHAR(128)" +
-               ", CONSTRAINT cnst1 FOREIGN KEY(parentId) REFERENCES (id)"
-               + ")");
-
-         // store parent
-         FieldAccessedSelfJoin parent = new FieldAccessedSelfJoin();
-         parent.type = "parent";
-         SqlClosureElf.insertObject(parent);
-         assertTrue(parent.id > 0);
-
-         // SansOrm does not persist child when parent is persisted
-         FieldAccessedSelfJoin child = new FieldAccessedSelfJoin();
-         child.type = "child";
-         child.parentId = parent;
-         SqlClosureElf.updateObject(parent);
-         assertEquals(0, child.id);
-
-         // persist child explicitely. parentId from parent is also stored.
-         OrmWriter.insertObject(con, child);
-         assertTrue(child.id > 0);
-         int count = SqlClosureElf.countObjectsFromClause(FieldAccessedSelfJoin.class, null);
-         assertEquals(2, count);
-
-         // Load child together with parent instance. Only parent id is restored on parent instance, no further attributes.
-         FieldAccessedSelfJoin childFromDb = SqlClosureElf.objectFromClause
-            (FieldAccessedSelfJoin.class, "id=2");
-//         PropertyAccessedOneToOneSelfJoin childFromDb = OrmElf.objectById(con, PropertyAccessedOneToOneSelfJoin.class, 2);
-         assertNotNull(childFromDb.parentId);
-         assertEquals(1, childFromDb.parentId.id);
-
-         // To add remaining attributes to parent reload
-         assertEquals(null, childFromDb.parentId.type);
-         OrmElf.refresh(con, childFromDb.parentId);
-         assertEquals("parent", childFromDb.parentId.type);
-      }
-      finally {
-         SqlClosureElf.executeUpdate("DROP TABLE JOINTEST");
-      }
-   }
-
-   @Test
    public void introspectJoinColumn() {
 
       Introspected introspected = new Introspected(FieldAccessedSelfJoin.class);
@@ -111,7 +60,7 @@ public class SelfJoinManyToOneFieldAccessTest {
    }
 
    @Test
-   public void selfJoinColumnPropertyAccessH2() throws SQLException {
+   public void selfJoinColumnH2() throws SQLException {
 
       JdbcDataSource ds = TestUtils.makeH2DataSource();
       SansOrm.initializeTxNone(ds);

--- a/src/test/java/com/zaxxer/sansorm/internal/SelfJoinManyToOneFieldAccessTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/SelfJoinManyToOneFieldAccessTest.java
@@ -1,0 +1,240 @@
+package com.zaxxer.sansorm.internal;
+
+import com.zaxxer.sansorm.OrmElf;
+import com.zaxxer.sansorm.SansOrm;
+import com.zaxxer.sansorm.SqlClosureElf;
+import org.assertj.core.api.Assertions;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.Test;
+import org.sansorm.TestUtils;
+
+import javax.persistence.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class SelfJoinManyToOneFieldAccessTest {
+
+   @Test
+   public void selfJoinFieldAccess() {
+      class Test {
+         @JoinColumn(name = "id", referencedColumnName = "parentId")
+         private Test parent;
+      }
+      Introspected introspected = new Introspected(Test.class);
+      AttributeInfo info = introspected.getSelfJoinColumnInfo();
+      assertTrue(info.isToBeConsidered());
+   }
+
+   @Table(name = "JOINTEST")
+   public static class FieldAccessedSelfJoin {
+      @Id @GeneratedValue
+      private int id;
+      @ManyToOne
+      @JoinColumn(name = "parentId", referencedColumnName = "id")
+      private FieldAccessedSelfJoin parentId;
+      private String type;
+
+      @Override
+      public String toString() {
+         return "Test{" +
+            "id=" + id +
+            ", parentId=" + parentId +
+            ", type='" + type + '\'' +
+            '}';
+      }
+   }
+
+   @Test
+   public void selfJoinColumnFieldAccessH2() throws SQLException {
+
+      JdbcDataSource ds = TestUtils.makeH2DataSource();
+      SansOrm.initializeTxNone(ds);
+      try (Connection con = ds.getConnection()){
+         SqlClosureElf.executeUpdate(
+            " CREATE TABLE JOINTEST (" +
+               " "
+               + "id INTEGER NOT NULL IDENTITY PRIMARY KEY"
+               + ", parentId INTEGER"
+               + ", type VARCHAR(128)" +
+               ", CONSTRAINT cnst1 FOREIGN KEY(parentId) REFERENCES (id)"
+               + ")");
+
+         // store parent
+         FieldAccessedSelfJoin parent = new FieldAccessedSelfJoin();
+         parent.type = "parent";
+         SqlClosureElf.insertObject(parent);
+         assertTrue(parent.id > 0);
+
+         // SansOrm does not persist child when parent is persisted
+         FieldAccessedSelfJoin child = new FieldAccessedSelfJoin();
+         child.type = "child";
+         child.parentId = parent;
+         SqlClosureElf.updateObject(parent);
+         assertEquals(0, child.id);
+
+         // persist child explicitely. parentId from parent is also stored.
+         OrmWriter.insertObject(con, child);
+         assertTrue(child.id > 0);
+         int count = SqlClosureElf.countObjectsFromClause(FieldAccessedSelfJoin.class, null);
+         assertEquals(2, count);
+
+         // Load child together with parent instance. Only parent id is restored on parent instance, no further attributes.
+         FieldAccessedSelfJoin childFromDb = SqlClosureElf.objectFromClause
+            (FieldAccessedSelfJoin.class, "id=2");
+//         PropertyAccessedOneToOneSelfJoin childFromDb = OrmElf.objectById(con, PropertyAccessedOneToOneSelfJoin.class, 2);
+         assertNotNull(childFromDb.parentId);
+         assertEquals(1, childFromDb.parentId.id);
+
+         // To add remaining attributes to parent reload
+         assertEquals(null, childFromDb.parentId.type);
+         OrmElf.refresh(con, childFromDb.parentId);
+         assertEquals("parent", childFromDb.parentId.type);
+      }
+      finally {
+         SqlClosureElf.executeUpdate("DROP TABLE JOINTEST");
+      }
+   }
+
+   @Test
+   public void introspectJoinColumn() {
+
+      Introspected introspected = new Introspected(FieldAccessedSelfJoin.class);
+      AttributeInfo[] insertableFcInfos = introspected.getInsertableFcInfos();
+//      Arrays.stream(insertableFcInfos).forEach(System.out::println);
+      assertEquals(2, insertableFcInfos.length);
+   }
+
+   @Test
+   public void selfJoinColumnPropertyAccessH2() throws SQLException {
+
+      JdbcDataSource ds = TestUtils.makeH2DataSource();
+      SansOrm.initializeTxNone(ds);
+      try (Connection con = ds.getConnection()){
+         SqlClosureElf.executeUpdate(
+            " CREATE TABLE JOINTEST (" +
+               " "
+               + "id INTEGER NOT NULL IDENTITY PRIMARY KEY"
+               + ", parentId INTEGER"
+               + ", type VARCHAR(128)" +
+               ", CONSTRAINT cnst1 FOREIGN KEY(parentId) REFERENCES (id)"
+               + ")");
+
+         // store parent
+         FieldAccessedSelfJoin parent = new FieldAccessedSelfJoin();
+         parent.type = "parent";
+         SqlClosureElf.insertObject(parent);
+         assertTrue(parent.id > 0);
+
+         // SansOrm does not persist child when parent is persisted
+         FieldAccessedSelfJoin child = new FieldAccessedSelfJoin();
+         child.type = "child";
+         child.parentId = parent;
+         SqlClosureElf.updateObject(parent);
+         assertEquals(0, child.id);
+
+         // persist child explicitely. parentId from parent is also stored.
+         OrmWriter.insertObject(con, child);
+         assertTrue(child.id > 0);
+         int count = SqlClosureElf.countObjectsFromClause(FieldAccessedSelfJoin.class, null);
+         assertEquals(2, count);
+
+         // Load child together with parent instance. Only parent id is restored on parent instance, no further attributes.
+         FieldAccessedSelfJoin childFromDb = SqlClosureElf.objectFromClause
+            (FieldAccessedSelfJoin.class, "id=2");
+//         PropertyAccessedOneToOneSelfJoin childFromDb = OrmElf.objectById(con, PropertyAccessedOneToOneSelfJoin.class, 2);
+         assertNotNull(childFromDb.parentId);
+         assertEquals(1, childFromDb.parentId.id);
+
+         // To add remaining attributes to parent reload
+         assertEquals(null, childFromDb.parentId.type);
+         OrmElf.refresh(con, childFromDb.parentId);
+         assertEquals("parent", childFromDb.parentId.type);
+      }
+      finally {
+         SqlClosureElf.executeUpdate("DROP TABLE JOINTEST");
+      }
+   }
+
+   @Test
+   public void listFromClause() throws SQLException {
+
+      JdbcDataSource ds = TestUtils.makeH2DataSource();
+      SansOrm.initializeTxNone(ds);
+      try (Connection con = ds.getConnection()){
+         SqlClosureElf.executeUpdate(
+            " CREATE TABLE JOINTEST (" +
+               " "
+               + "id INTEGER NOT NULL IDENTITY PRIMARY KEY"
+               + ", parentId INTEGER"
+               + ", type VARCHAR(128)" +
+               ", CONSTRAINT cnst1 FOREIGN KEY(parentId) REFERENCES (id)"
+               + ")");
+
+         FieldAccessedSelfJoin parent = new FieldAccessedSelfJoin();
+         parent.type = "parent";
+         SqlClosureElf.insertObject(parent);
+
+         FieldAccessedSelfJoin child = new FieldAccessedSelfJoin();
+         child.type = "child";
+         child.parentId = parent;
+         OrmWriter.insertObject(con, child);
+
+         List<FieldAccessedSelfJoin> objs = SqlClosureElf.listFromClause(FieldAccessedSelfJoin.class, "id=2");
+         objs.forEach(System.out::println);
+         Assertions.assertThat(objs).filteredOn(obj -> obj.parentId != null && obj.parentId.id == 1).size().isEqualTo(1);
+      }
+      finally {
+         SqlClosureElf.executeUpdate("DROP TABLE JOINTEST");
+      }
+   }
+
+   @Test
+   public void insertListNotBatched() throws SQLException {
+
+      JdbcDataSource ds = TestUtils.makeH2DataSource();
+      SansOrm.initializeTxNone(ds);
+      try (Connection con = ds.getConnection()){
+         SqlClosureElf.executeUpdate(
+            " CREATE TABLE JOINTEST (" +
+               " "
+               + "id INTEGER NOT NULL IDENTITY PRIMARY KEY"
+               + ", parentId INTEGER"
+               + ", type VARCHAR(128)" +
+               ", CONSTRAINT cnst1 FOREIGN KEY(parentId) REFERENCES (id)"
+               + ")");
+
+         FieldAccessedSelfJoin parent = new FieldAccessedSelfJoin();
+         parent.type = "parent";
+         SqlClosureElf.insertObject(parent);
+
+         FieldAccessedSelfJoin parent2 = new FieldAccessedSelfJoin();
+         parent2.type = "parent";
+         SqlClosureElf.insertObject(parent2);
+
+         FieldAccessedSelfJoin child = new FieldAccessedSelfJoin();
+         child.type = "child";
+         child.parentId = parent;
+
+         FieldAccessedSelfJoin child2 = new FieldAccessedSelfJoin();
+         child2.type = "child";
+         child2.parentId = parent2;
+
+         ArrayList<FieldAccessedSelfJoin> children = new ArrayList<>();
+         children.add(child);
+         children.add(child2);
+
+         OrmWriter.insertListNotBatched(con, children);
+
+      }
+      finally {
+         SqlClosureElf.executeUpdate("DROP TABLE JOINTEST");
+      }
+   }
+
+}

--- a/src/test/java/com/zaxxer/sansorm/internal/SelfJoinManyToOnePropertyAccessTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/SelfJoinManyToOnePropertyAccessTest.java
@@ -1,0 +1,213 @@
+package com.zaxxer.sansorm.internal;
+
+import com.zaxxer.sansorm.OrmElf;
+import com.zaxxer.sansorm.SansOrm;
+import com.zaxxer.sansorm.SqlClosureElf;
+import org.assertj.core.api.Assertions;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.Test;
+import org.sansorm.TestUtils;
+
+import javax.persistence.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class SelfJoinManyToOnePropertyAccessTest {
+
+   @Test
+   public void selfJoinFieldAccess() {
+      class Test {
+         @JoinColumn(name = "id", referencedColumnName = "parentId")
+         private Test parent;
+      }
+      Introspected introspected = new Introspected(Test.class);
+      AttributeInfo info = introspected.getSelfJoinColumnInfo();
+      assertTrue(info.isToBeConsidered());
+   }
+
+   @Table(name = "JOINTEST")
+   public static class PropertyAccessedSelfJoin {
+      private int id;
+      private PropertyAccessedSelfJoin parentId;
+      private String type;
+
+      @Override
+      public String toString() {
+         return "Test{" +
+            "id=" + id +
+            ", parentId=" + parentId +
+            ", type='" + type + '\'' +
+            '}';
+      }
+
+      @Id @GeneratedValue
+      public int getId() {
+         return id;
+      }
+
+      public void setId(int id) {
+         this.id = id;
+      }
+
+      @ManyToOne
+      @JoinColumn(name = "parentId", referencedColumnName = "id")
+      public PropertyAccessedSelfJoin getParentId() {
+         return parentId;
+      }
+
+      public void setParentId(PropertyAccessedSelfJoin parentId) {
+         this.parentId = parentId;
+      }
+
+      public String getType() {
+         return type;
+      }
+
+      public void setType(String type) {
+         this.type = type;
+      }
+   }
+
+   @Test
+   public void introspectJoinColumn() {
+
+      Introspected introspected = new Introspected(PropertyAccessedSelfJoin.class);
+      AttributeInfo[] insertableFcInfos = introspected.getInsertableFcInfos();
+//      Arrays.stream(insertableFcInfos).forEach(System.out::println);
+      assertEquals(2, insertableFcInfos.length);
+   }
+
+   @Test
+   public void selfJoinColumnPropertyAccessH2() throws SQLException {
+
+      JdbcDataSource ds = TestUtils.makeH2DataSource();
+      SansOrm.initializeTxNone(ds);
+      try (Connection con = ds.getConnection()){
+         SqlClosureElf.executeUpdate(
+            " CREATE TABLE JOINTEST (" +
+               " "
+               + "id INTEGER NOT NULL IDENTITY PRIMARY KEY"
+               + ", parentId INTEGER"
+               + ", type VARCHAR(128)" +
+               ", CONSTRAINT cnst1 FOREIGN KEY(parentId) REFERENCES (id)"
+               + ")");
+
+         // store parent
+         PropertyAccessedSelfJoin parent = new PropertyAccessedSelfJoin();
+         parent.type = "parent";
+         SqlClosureElf.insertObject(parent);
+         assertTrue(parent.id > 0);
+
+         // SansOrm does not persist child when parent is persisted
+         PropertyAccessedSelfJoin child = new PropertyAccessedSelfJoin();
+         child.type = "child";
+         child.parentId = parent;
+         SqlClosureElf.updateObject(parent);
+         assertEquals(0, child.id);
+
+         // persist child explicitely. parentId from parent is also stored.
+         OrmWriter.insertObject(con, child);
+         assertTrue(child.id > 0);
+         int count = SqlClosureElf.countObjectsFromClause(PropertyAccessedSelfJoin.class, null);
+         assertEquals(2, count);
+
+         // Load child together with parent instance. Only parent id is restored on parent instance, no further attributes.
+         PropertyAccessedSelfJoin childFromDb = SqlClosureElf.objectFromClause
+            (PropertyAccessedSelfJoin.class, "id=2");
+//         PropertyAccessedOneToOneSelfJoin childFromDb = OrmElf.objectById(con, PropertyAccessedOneToOneSelfJoin.class, 2);
+         assertNotNull(childFromDb.parentId);
+         assertEquals(1, childFromDb.parentId.id);
+
+         // To add remaining attributes to parent reload
+         assertEquals(null, childFromDb.parentId.type);
+         OrmElf.refresh(con, childFromDb.parentId);
+         assertEquals("parent", childFromDb.parentId.type);
+      }
+      finally {
+         SqlClosureElf.executeUpdate("DROP TABLE JOINTEST");
+      }
+   }
+
+   @Test
+   public void listFromClause() throws SQLException {
+
+      JdbcDataSource ds = TestUtils.makeH2DataSource();
+      SansOrm.initializeTxNone(ds);
+      try (Connection con = ds.getConnection()){
+         SqlClosureElf.executeUpdate(
+            " CREATE TABLE JOINTEST (" +
+               " "
+               + "id INTEGER NOT NULL IDENTITY PRIMARY KEY"
+               + ", parentId INTEGER"
+               + ", type VARCHAR(128)" +
+               ", CONSTRAINT cnst1 FOREIGN KEY(parentId) REFERENCES (id)"
+               + ")");
+
+         PropertyAccessedSelfJoin parent = new PropertyAccessedSelfJoin();
+         parent.type = "parent";
+         SqlClosureElf.insertObject(parent);
+
+         PropertyAccessedSelfJoin child = new PropertyAccessedSelfJoin();
+         child.type = "child";
+         child.parentId = parent;
+         OrmWriter.insertObject(con, child);
+
+         List<PropertyAccessedSelfJoin> objs = SqlClosureElf.listFromClause(PropertyAccessedSelfJoin.class, "id=2");
+         objs.forEach(System.out::println);
+         Assertions.assertThat(objs).filteredOn(obj -> obj.parentId != null && obj.parentId.id == 1).size().isEqualTo(1);
+      }
+      finally {
+         SqlClosureElf.executeUpdate("DROP TABLE JOINTEST");
+      }
+   }
+
+   @Test
+   public void insertListNotBatched() throws SQLException {
+
+      JdbcDataSource ds = TestUtils.makeH2DataSource();
+      SansOrm.initializeTxNone(ds);
+      try (Connection con = ds.getConnection()){
+         SqlClosureElf.executeUpdate(
+            " CREATE TABLE JOINTEST (" +
+               " "
+               + "id INTEGER NOT NULL IDENTITY PRIMARY KEY"
+               + ", parentId INTEGER"
+               + ", type VARCHAR(128)" +
+               ", CONSTRAINT cnst1 FOREIGN KEY(parentId) REFERENCES (id)"
+               + ")");
+
+         PropertyAccessedSelfJoin parent = new PropertyAccessedSelfJoin();
+         parent.type = "parent";
+         SqlClosureElf.insertObject(parent);
+
+         PropertyAccessedSelfJoin parent2 = new PropertyAccessedSelfJoin();
+         parent2.type = "parent";
+         SqlClosureElf.insertObject(parent2);
+
+         PropertyAccessedSelfJoin child = new PropertyAccessedSelfJoin();
+         child.type = "child";
+         child.parentId = parent;
+
+         PropertyAccessedSelfJoin child2 = new PropertyAccessedSelfJoin();
+         child2.type = "child";
+         child2.parentId = parent2;
+
+         ArrayList<PropertyAccessedSelfJoin> children = new ArrayList<>();
+         children.add(child);
+         children.add(child2);
+
+         OrmWriter.insertListNotBatched(con, children);
+
+      }
+      finally {
+         SqlClosureElf.executeUpdate("DROP TABLE JOINTEST");
+      }
+   }
+
+}

--- a/src/test/java/com/zaxxer/sansorm/internal/SelfJoinOneToOnePropertyAccessTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/SelfJoinOneToOnePropertyAccessTest.java
@@ -87,7 +87,7 @@ public class SelfJoinOneToOnePropertyAccessTest {
    }
 
    @Test
-   public void selfJoinColumnPropertyAccessH2() throws SQLException {
+   public void selfJoinColumnH2() throws SQLException {
 
       JdbcDataSource ds = TestUtils.makeH2DataSource();
       SansOrm.initializeTxNone(ds);

--- a/src/test/java/com/zaxxer/sansorm/internal/SelfJoinOneToOnePropertyAccessTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/SelfJoinOneToOnePropertyAccessTest.java
@@ -213,4 +213,6 @@ public class SelfJoinOneToOnePropertyAccessTest {
       }
    }
 
+   // TODO Restriction found: annotations with identical field names (e. g. '@Id @Column(name = "identicalFieldName")' and @JoinColumn(name = "identicalFieldName")') will overwrite each other in Introspected.columnToField
+
 }

--- a/src/test/java/com/zaxxer/sansorm/internal/SelfJoinOneToOnePropertyAccessTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/SelfJoinOneToOnePropertyAccessTest.java
@@ -20,18 +20,8 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-/**
- * In general associations are not supported with one exception in {@link OrmReader#resultSetToList(ResultSet, Class)} where a OneToOne self reference is resolved. This method is called from
- * <pre>
- * {@link com.zaxxer.sansorm.OrmElf#resultSetToList(ResultSet, Class)}
- * {@link com.zaxxer.sansorm.OrmElf#statementToList(PreparedStatement, Class, Object...)}
- * {@link com.zaxxer.sansorm.OrmElf#listFromClause(Connection, Class, String, Object...)}
- * {@link com.zaxxer.sansorm.SqlClosureElf#listFromClause(Class, String, Object...)}
- *
- * @author Holger Thurow (thurow.h@gmail.com)
- * @since 01.05.18
- */
-public class SelfJoinOneToOneTest {
+
+public class SelfJoinOneToOnePropertyAccessTest {
 
    @org.junit.Test
    public void selfJoinFieldAccess() {
@@ -43,71 +33,6 @@ public class SelfJoinOneToOneTest {
       AttributeInfo info = introspected.getSelfJoinColumnInfo();
       assertTrue(info.isToBeConsidered());
    }
-
-   @Table
-   public static class FieldAccessedOneToOneSelfJoin {
-      @Id @GeneratedValue
-      private int id;
-      @JoinColumn(name = "parentId", referencedColumnName = "id")
-      private FieldAccessedOneToOneSelfJoin parentId;
-      private String type;
-
-      @Override
-      public String toString() {
-         return "Test{" +
-            "id=" + id +
-            ", parentId=" + parentId +
-            ", type='" + type + '\'' +
-            '}';
-      }
-   }
-
-//   /**
-//    * Support for referenced columns that are not primary key columns of the referenced table is optional. Applications that use such mappings will not be portable. (JSR 317: JavaTM Persistence API, Version 2.0, 11.1.21 JoinColumn Annotation)
-//    */
-//   @Test
-//   public void selfJoinColumnH2() throws SQLException {
-//
-//      JdbcDataSource ds = TestUtils.makeH2DataSource();
-//      SansOrm.initializeTxNone(ds);
-//      try (Connection con = ds.getConnection()){
-//         SqlClosureElf.executeUpdate(
-//            " CREATE TABLE JOINTEST (" +
-//               " "
-//               + "id INTEGER NOT NULL IDENTITY PRIMARY KEY"
-//               + ", parentId INTEGER"
-//               + ", type VARCHAR(128)" +
-//               ", CONSTRAINT cnst1 FOREIGN KEY(parentId) REFERENCES (id)"
-//               + ")");
-//         FieldAccessedOneToOneSelfJoin parent = new FieldAccessedOneToOneSelfJoin();
-//         parent.type = "parent";
-//         SqlClosureElf.insertObject(parent);
-//
-//         // SansOrm does not persist children
-//         FieldAccessedOneToOneSelfJoin child = new FieldAccessedOneToOneSelfJoin();
-//         child.type = "child";
-//         child.parentId = parent;
-//         SqlClosureElf.updateObject(parent);
-//         assertEquals(0, child.id);
-//
-//         // persist child explicitely
-//         OrmWriter.insertObject(con, child);
-//         assertTrue(child.id > 0);
-//         int count = SqlClosureElf.countObjectsFromClause(FieldAccessedOneToOneSelfJoin.class, null);
-//         assertEquals(2, count);
-//
-//         // child retrieved, but without parent
-//         FieldAccessedOneToOneSelfJoin obj3 = SqlClosureElf.objectFromClause(FieldAccessedOneToOneSelfJoin.class, "id=2");
-//         assertEquals(null, obj3.parentId);
-//
-//         // child retrieved, but without parent
-//         List<FieldAccessedOneToOneSelfJoin> objs = SqlClosureElf.listFromClause(FieldAccessedOneToOneSelfJoin.class, "id=2");
-//         objs.forEach(System.out::println);
-//      }
-//      finally {
-//         SqlClosureElf.executeUpdate("DROP TABLE JOINTEST");
-//      }
-//   }
 
    @Table(name = "JOINTEST")
    public static class PropertyAccessedOneToOneSelfJoin {

--- a/src/test/java/com/zaxxer/sansorm/internal/SelfJoinOneToOneTest.java
+++ b/src/test/java/com/zaxxer/sansorm/internal/SelfJoinOneToOneTest.java
@@ -1,0 +1,246 @@
+package com.zaxxer.sansorm.internal;
+
+import com.zaxxer.sansorm.OrmElf;
+import com.zaxxer.sansorm.SansOrm;
+import com.zaxxer.sansorm.SqlClosure;
+import com.zaxxer.sansorm.SqlClosureElf;
+import org.assertj.core.api.Assertions;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.Test;
+import org.sansorm.TestUtils;
+
+import javax.persistence.*;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * In general associations are not supported with one exception in {@link OrmReader#resultSetToList(ResultSet, Class)} where a OneToOne self reference is resolved. This method is called from
+ * <pre>
+ * {@link com.zaxxer.sansorm.OrmElf#resultSetToList(ResultSet, Class)}
+ * {@link com.zaxxer.sansorm.OrmElf#statementToList(PreparedStatement, Class, Object...)}
+ * {@link com.zaxxer.sansorm.OrmElf#listFromClause(Connection, Class, String, Object...)}
+ * {@link com.zaxxer.sansorm.SqlClosureElf#listFromClause(Class, String, Object...)}
+ *
+ * @author Holger Thurow (thurow.h@gmail.com)
+ * @since 01.05.18
+ */
+public class SelfJoinOneToOneTest {
+
+   @org.junit.Test
+   public void selfJoinFieldAccess() {
+      class Test {
+         @JoinColumn(name = "id", referencedColumnName = "parentId")
+         private Test parent;
+      }
+      Introspected introspected = new Introspected(Test.class);
+      AttributeInfo info = introspected.getSelfJoinColumnInfo();
+      assertTrue(info.isToBeConsidered());
+   }
+
+   @Table
+   public static class FieldAccessedOneToOneSelfJoin {
+      @Id @GeneratedValue
+      private int id;
+      @JoinColumn(name = "parentId", referencedColumnName = "id")
+      private FieldAccessedOneToOneSelfJoin parentId;
+      private String type;
+
+      @Override
+      public String toString() {
+         return "Test{" +
+            "id=" + id +
+            ", parentId=" + parentId +
+            ", type='" + type + '\'' +
+            '}';
+      }
+   }
+
+//   /**
+//    * Support for referenced columns that are not primary key columns of the referenced table is optional. Applications that use such mappings will not be portable. (JSR 317: JavaTM Persistence API, Version 2.0, 11.1.21 JoinColumn Annotation)
+//    */
+//   @Test
+//   public void selfJoinColumnH2() throws SQLException {
+//
+//      JdbcDataSource ds = TestUtils.makeH2DataSource();
+//      SansOrm.initializeTxNone(ds);
+//      try (Connection con = ds.getConnection()){
+//         SqlClosureElf.executeUpdate(
+//            " CREATE TABLE JOINTEST (" +
+//               " "
+//               + "id INTEGER NOT NULL IDENTITY PRIMARY KEY"
+//               + ", parentId INTEGER"
+//               + ", type VARCHAR(128)" +
+//               ", CONSTRAINT cnst1 FOREIGN KEY(parentId) REFERENCES (id)"
+//               + ")");
+//         FieldAccessedOneToOneSelfJoin parent = new FieldAccessedOneToOneSelfJoin();
+//         parent.type = "parent";
+//         SqlClosureElf.insertObject(parent);
+//
+//         // SansOrm does not persist children
+//         FieldAccessedOneToOneSelfJoin child = new FieldAccessedOneToOneSelfJoin();
+//         child.type = "child";
+//         child.parentId = parent;
+//         SqlClosureElf.updateObject(parent);
+//         assertEquals(0, child.id);
+//
+//         // persist child explicitely
+//         OrmWriter.insertObject(con, child);
+//         assertTrue(child.id > 0);
+//         int count = SqlClosureElf.countObjectsFromClause(FieldAccessedOneToOneSelfJoin.class, null);
+//         assertEquals(2, count);
+//
+//         // child retrieved, but without parent
+//         FieldAccessedOneToOneSelfJoin obj3 = SqlClosureElf.objectFromClause(FieldAccessedOneToOneSelfJoin.class, "id=2");
+//         assertEquals(null, obj3.parentId);
+//
+//         // child retrieved, but without parent
+//         List<FieldAccessedOneToOneSelfJoin> objs = SqlClosureElf.listFromClause(FieldAccessedOneToOneSelfJoin.class, "id=2");
+//         objs.forEach(System.out::println);
+//      }
+//      finally {
+//         SqlClosureElf.executeUpdate("DROP TABLE JOINTEST");
+//      }
+//   }
+
+   @Table(name = "JOINTEST")
+   public static class PropertyAccessedOneToOneSelfJoin {
+      private int id;
+      private PropertyAccessedOneToOneSelfJoin parentId;
+      private String type;
+
+      @Override
+      public String toString() {
+         return "Test{" +
+            "id=" + id +
+            ", parentId=" + parentId +
+            ", type='" + type + '\'' +
+            '}';
+      }
+
+      @Id @GeneratedValue
+      public int getId() {
+         return id;
+      }
+
+      public void setId(int id) {
+         this.id = id;
+      }
+
+      @OneToOne
+      @JoinColumn(name = "parentId", referencedColumnName = "id")
+      public PropertyAccessedOneToOneSelfJoin getParentId() {
+         return parentId;
+      }
+
+      public void setParentId(PropertyAccessedOneToOneSelfJoin parentId) {
+         this.parentId = parentId;
+      }
+
+      public String getType() {
+         return type;
+      }
+
+      public void setType(String type) {
+         this.type = type;
+      }
+   }
+
+   @Test
+   public void introspectJoinColumn() {
+
+      Introspected introspected = new Introspected(PropertyAccessedOneToOneSelfJoin.class);
+      AttributeInfo[] insertableFcInfos = introspected.getInsertableFcInfos();
+//      Arrays.stream(insertableFcInfos).forEach(System.out::println);
+      assertEquals(2, insertableFcInfos.length);
+   }
+
+   @Test
+   public void selfJoinColumnPropertyAccessH2() throws SQLException {
+
+      JdbcDataSource ds = TestUtils.makeH2DataSource();
+      SansOrm.initializeTxNone(ds);
+      try (Connection con = ds.getConnection()){
+         SqlClosureElf.executeUpdate(
+            " CREATE TABLE JOINTEST (" +
+               " "
+               + "id INTEGER NOT NULL IDENTITY PRIMARY KEY"
+               + ", parentId INTEGER"
+               + ", type VARCHAR(128)" +
+               ", CONSTRAINT cnst1 FOREIGN KEY(parentId) REFERENCES (id)"
+               + ")");
+
+         // store parent
+         PropertyAccessedOneToOneSelfJoin parent = new PropertyAccessedOneToOneSelfJoin();
+         parent.type = "parent";
+         SqlClosureElf.insertObject(parent);
+         assertTrue(parent.id > 0);
+
+         // SansOrm does not persist child when parent is persisted
+         PropertyAccessedOneToOneSelfJoin child = new PropertyAccessedOneToOneSelfJoin();
+         child.type = "child";
+         child.parentId = parent;
+         SqlClosureElf.updateObject(parent);
+         assertEquals(0, child.id);
+
+         // persist child explicitely. parentId from parent is also stored.
+         OrmWriter.insertObject(con, child);
+         assertTrue(child.id > 0);
+         int count = SqlClosureElf.countObjectsFromClause(PropertyAccessedOneToOneSelfJoin.class, null);
+         assertEquals(2, count);
+
+         // Load child together with parent instance. Only parent id is restored on parent instance, no further attributes.
+         PropertyAccessedOneToOneSelfJoin childFromDb = SqlClosureElf.objectFromClause
+            (PropertyAccessedOneToOneSelfJoin.class, "id=2");
+//         PropertyAccessedOneToOneSelfJoin childFromDb = OrmElf.objectById(con, PropertyAccessedOneToOneSelfJoin.class, 2);
+         assertNotNull(childFromDb.parentId);
+         assertEquals(1, childFromDb.parentId.id);
+
+         // To add remaining attributes to parent reload
+         assertEquals(null, childFromDb.parentId.type);
+         OrmElf.refresh(con, childFromDb.parentId);
+         assertEquals("parent", childFromDb.parentId.type);
+      }
+      finally {
+         SqlClosureElf.executeUpdate("DROP TABLE JOINTEST");
+      }
+   }
+
+   @Test
+   public void listFromClause() throws SQLException {
+
+      JdbcDataSource ds = TestUtils.makeH2DataSource();
+      SansOrm.initializeTxNone(ds);
+      try (Connection con = ds.getConnection()){
+         SqlClosureElf.executeUpdate(
+            " CREATE TABLE JOINTEST (" +
+               " "
+               + "id INTEGER NOT NULL IDENTITY PRIMARY KEY"
+               + ", parentId INTEGER"
+               + ", type VARCHAR(128)" +
+               ", CONSTRAINT cnst1 FOREIGN KEY(parentId) REFERENCES (id)"
+               + ")");
+
+         PropertyAccessedOneToOneSelfJoin parent = new PropertyAccessedOneToOneSelfJoin();
+         parent.type = "parent";
+         SqlClosureElf.insertObject(parent);
+
+         PropertyAccessedOneToOneSelfJoin child = new PropertyAccessedOneToOneSelfJoin();
+         child.type = "child";
+         child.parentId = parent;
+         OrmWriter.insertObject(con, child);
+
+         List<PropertyAccessedOneToOneSelfJoin> objs = SqlClosureElf.listFromClause(PropertyAccessedOneToOneSelfJoin.class, "id=2");
+         objs.forEach(System.out::println);
+         Assertions.assertThat(objs).filteredOn(obj -> obj.parentId != null && obj.parentId.id == 1).size().isEqualTo(1);
+      }
+      finally {
+         SqlClosureElf.executeUpdate("DROP TABLE JOINTEST");
+      }
+   }
+}


### PR DESCRIPTION
IntelliJ can reverse engineer a database schema to JPA annotated entity classes what is very convenient. The problem is that it only annotates getters not fields. So it is preferable that SansOrm supports property access too, not only field access.

Property access has another advantage. It offers more control about the process of reading or writing field values, e. g. one can leverage JavaBean's PropertyChangeSupport.

JPA defines the `@Access` annotation to explicitly set field or property access per class or attribute. Also there is a default access type detecting process described in case there is no explicit access type set. SansOrm does now follow the specification herein.

I did not publish directly to origin/master in case you still want to try to clean up the last commit.