### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <sureFireOptions9 />
       <sureFireForks9>false</sureFireForks9>
+   	<closeTestReports>true</closeTestReports>
    </properties>
 
    <parent>
@@ -175,6 +176,7 @@
                <!-- Skips unit tests if the value of skip.unit.tests property is true -->
                <skipTests>${skip.unit.tests}</skipTests>
                <reuseForks>${sureFireForks9}</reuseForks>
+            	<disableXmlReport>${closeTestReports}</disableXmlReport>
             </configuration>
          </plugin>
 


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
